### PR TITLE
feat(theory): prove Markov, Chebyshev, and Weak LLN with convergence demo

### DIFF
--- a/exercises/ex02_convergence.md
+++ b/exercises/ex02_convergence.md
@@ -1,0 +1,105 @@
+# Exercises — Phase 2: Convergence Theorems
+
+These exercises reinforce the proof chain Markov → Chebyshev → WLLN and
+build intuition for Monte Carlo convergence. Solve on paper.
+
+---
+
+## Proofs (paper)
+
+### Exercise 1 — Prove Markov's Inequality
+
+**Prove** Markov's inequality from the definition of expectation: for a
+non-negative random variable $X$ and $a > 0$:
+
+$$
+P(X \geq a) \leq \frac{E[X]}{a}
+$$
+
+*Hint: split the integral $E[X] = \int_0^{\infty} x \, f_X(x) \, dx$ at $a$
+and bound the integrand in the region $[a, \infty)$.*
+
+---
+
+### Exercise 2 — Derive Chebyshev's Inequality
+
+**Derive** Chebyshev's inequality as a corollary of Markov's inequality applied
+to $Y = (X - \mu)^2$:
+
+$$
+P(|X - \mu| \geq \epsilon) \leq \frac{\sigma^2}{\epsilon^2}
+$$
+
+*Show each step of the substitution: define $Y$, verify $Y \geq 0$,
+identify the equivalent event, apply Markov, and simplify.*
+
+---
+
+### Exercise 3 — Prove the Weak Law of Large Numbers
+
+**Prove** the Weak Law of Large Numbers for i.i.d. random variables with
+finite variance:
+
+If $X_1, \ldots, X_n$ are i.i.d. with $E[X_i] = \mu$ and
+$\text{Var}(X_i) = \sigma^2 < \infty$, then for every $\epsilon > 0$:
+
+$$
+\lim_{n \to \infty} P(|\bar{X}_n - \mu| \geq \epsilon) = 0
+$$
+
+*Use Chebyshev's inequality on $\bar{X}_n$. The proof has four steps:
+(1) compute $E[\bar{X}_n]$, (2) compute $\text{Var}(\bar{X}_n)$,
+(3) apply Chebyshev, (4) take the limit.*
+
+---
+
+### Exercise 4 — Variance Decay: Necessary but Not Sufficient?
+
+**Prove** that $\text{Var}(\bar{X}_n) \to 0$ is **necessary but not sufficient**
+for convergence in probability.
+
+*Part (a): Show that convergence in probability implies
+$\text{Var}(\bar{X}_n) \to 0$ when the variance exists. (Hint: if
+$\bar{X}_n \xrightarrow{P} \mu$, then $E[(\bar{X}_n - \mu)^2] \to 0$
+under bounded convergence.)*
+
+*Part (b): Explain why Chebyshev "closes the gap" — that is, why
+$\text{Var}(\bar{X}_n) \to 0$ is actually sufficient when combined with the
+Chebyshev inequality. What role does the bound
+$P(|\bar{X}_n - \mu| \geq \epsilon) \leq \text{Var}(\bar{X}_n)/\epsilon^2$
+play?*
+
+---
+
+## Computations (paper)
+
+### Exercise 5 — Minimum N via Chebyshev
+
+For $X \sim \text{LogNormal}(9.2, 0.09)$ (monthly salary):
+
+1. Compute $E[X]$ and $\text{Var}(X)$.
+2. Using Chebyshev's inequality, find the minimum $N$ such that:
+
+$$
+P(|\bar{X}_N - E[X]| \geq 500) \leq 0.05
+$$
+
+3. Interpret: what does this $N$ mean in the context of Monte Carlo simulation
+   of salary averages?
+
+---
+
+### Exercise 6 — Chebyshev Bound on a Simulation
+
+You simulate a budget 1,000 times and get $\bar{X}_{1000} = 12{,}340{,}000$
+with sample variance $s^2 = 2.5 \times 10^{12}$.
+
+1. Using Chebyshev, give an upper bound on:
+
+$$
+P(|E[X] - 12{,}340{,}000| \geq 100{,}000)
+$$
+
+2. Is this bound tight? What additional information would give a tighter bound?
+
+3. How many simulations would be needed to reduce this Chebyshev bound to 0.01?

--- a/notebooks/02_lln_convergence.ipynb
+++ b/notebooks/02_lln_convergence.ipynb
@@ -1,0 +1,390 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Phase 2 — LLN Convergence Demonstration\n",
+    "\n",
+    "This notebook visualises the **Law of Large Numbers** in action:\n",
+    "the sample mean of LogNormal salary draws stabilises around $E[S]$ as $N$ grows.\n",
+    "\n",
+    "We overlay **Chebyshev bounds** to show the theoretical guarantee:\n",
+    "\n",
+    "$$\n",
+    "P(|\\bar{X}_N - \\mu| \\geq \\epsilon) \\leq \\frac{\\sigma^2}{N \\epsilon^2}\n",
+    "$$\n",
+    "\n",
+    "Inverting for a confidence band at level $1 - \\alpha$:\n",
+    "\n",
+    "$$\n",
+    "\\bar{X}_N \\in \\left[\\mu - \\frac{\\sigma}{\\sqrt{N \\alpha}}, \\;\\; \\mu + \\frac{\\sigma}{\\sqrt{N \\alpha}}\\right]\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "\n",
+    "sns.set_theme(style=\"whitegrid\", palette=\"muted\", font_scale=1.1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Setup: Salary Distribution Parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# LogNormal parameters for salary\n",
+    "mu_s, sigma_s = 9.2, 0.3\n",
+    "\n",
+    "# Analytical moments\n",
+    "E_S = np.exp(mu_s + sigma_s**2 / 2)\n",
+    "Var_S = (np.exp(sigma_s**2) - 1) * np.exp(2 * mu_s + sigma_s**2)\n",
+    "SD_S = np.sqrt(Var_S)\n",
+    "\n",
+    "print(f\"E[S]   = R$ {E_S:,.2f}\")\n",
+    "print(f\"Var[S] = {Var_S:,.2f}\")\n",
+    "print(f\"SD[S]  = R$ {SD_S:,.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Running Mean — Single Run\n",
+    "\n",
+    "We draw $N = 10{,}000$ samples and compute the running mean $\\bar{X}_n$ for each $n$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N = 10_000\n",
+    "rng = np.random.default_rng(42)\n",
+    "samples = rng.lognormal(mean=mu_s, sigma=sigma_s, size=N)\n",
+    "\n",
+    "# Running mean: X̄_n for n = 1, 2, ..., N\n",
+    "running_mean = np.cumsum(samples) / np.arange(1, N + 1)\n",
+    "\n",
+    "print(f\"X̄_1     = R$ {running_mean[0]:,.2f}\")\n",
+    "print(f\"X̄_100   = R$ {running_mean[99]:,.2f}\")\n",
+    "print(f\"X̄_1000  = R$ {running_mean[999]:,.2f}\")\n",
+    "print(f\"X̄_10000 = R$ {running_mean[-1]:,.2f}\")\n",
+    "print(f\"E[S]     = R$ {E_S:,.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Chebyshev confidence band at 95% (alpha = 0.05)\n",
+    "alpha = 0.05\n",
+    "n_vals = np.arange(1, N + 1)\n",
+    "chebyshev_half_width = SD_S / np.sqrt(n_vals * alpha)\n",
+    "\n",
+    "upper_bound = E_S + chebyshev_half_width\n",
+    "lower_bound = E_S - chebyshev_half_width"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(12, 6))\n",
+    "\n",
+    "ax.plot(n_vals, running_mean, color=\"steelblue\", lw=0.8, alpha=0.9,\n",
+    "        label=r\"Running mean $\\bar{X}_n$\")\n",
+    "ax.axhline(E_S, color=\"red\", ls=\"--\", lw=1.5, label=f\"$E[S]$ = R$ {E_S:,.0f}\")\n",
+    "ax.fill_between(n_vals, lower_bound, upper_bound, alpha=0.15, color=\"orange\",\n",
+    "                label=r\"Chebyshev 95% band: $\\mu \\pm \\sigma/\\sqrt{n\\alpha}$\")\n",
+    "\n",
+    "ax.set_xlabel(\"Number of samples $n$\")\n",
+    "ax.set_ylabel(\"Sample mean (R$)\")\n",
+    "ax.set_title(\"Law of Large Numbers — Single Run\")\n",
+    "ax.legend(loc=\"upper right\")\n",
+    "ax.set_xlim(1, N)\n",
+    "ax.set_ylim(E_S - 4000, E_S + 4000)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Multiple Independent Runs\n",
+    "\n",
+    "To show the **variability** at small $N$ and **convergence** at large $N$,\n",
+    "we plot 10 independent runs on the same axes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_runs = 10\n",
+    "N = 10_000\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(12, 6))\n",
+    "\n",
+    "# Colour palette for runs\n",
+    "colors = plt.cm.tab10(np.linspace(0, 1, n_runs))\n",
+    "\n",
+    "for i in range(n_runs):\n",
+    "    run_rng = np.random.default_rng(seed=100 + i)\n",
+    "    run_samples = run_rng.lognormal(mean=mu_s, sigma=sigma_s, size=N)\n",
+    "    run_mean = np.cumsum(run_samples) / np.arange(1, N + 1)\n",
+    "    ax.plot(n_vals, run_mean, color=colors[i], lw=0.6, alpha=0.7)\n",
+    "\n",
+    "# True mean\n",
+    "ax.axhline(E_S, color=\"red\", ls=\"--\", lw=2,\n",
+    "           label=f\"$E[S]$ = R$ {E_S:,.0f}\")\n",
+    "\n",
+    "# Chebyshev band\n",
+    "ax.fill_between(n_vals, lower_bound, upper_bound, alpha=0.12, color=\"orange\",\n",
+    "                label=r\"Chebyshev 95% band\")\n",
+    "\n",
+    "ax.set_xlabel(\"Number of samples $n$\")\n",
+    "ax.set_ylabel(\"Sample mean (R$)\")\n",
+    "ax.set_title(f\"Law of Large Numbers — {n_runs} Independent Runs\")\n",
+    "ax.legend(loc=\"upper right\")\n",
+    "ax.set_xlim(1, N)\n",
+    "ax.set_ylim(E_S - 4000, E_S + 4000)\n",
+    "plt.tight_layout()\n",
+    "plt.savefig(\"../figures/lln_convergence.png\", dpi=300, bbox_inches=\"tight\")\n",
+    "plt.show()\n",
+    "\n",
+    "print(\"Saved: figures/lln_convergence.png\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Convergence Rate: Log Scale\n",
+    "\n",
+    "The Chebyshev band shrinks as $O(1/\\sqrt{n})$. On a log-log scale this\n",
+    "becomes a straight line with slope $-1/2$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 5))\n",
+    "\n",
+    "# Absolute error for each run\n",
+    "for i in range(n_runs):\n",
+    "    run_rng = np.random.default_rng(seed=100 + i)\n",
+    "    run_samples = run_rng.lognormal(mean=mu_s, sigma=sigma_s, size=N)\n",
+    "    run_mean = np.cumsum(run_samples) / np.arange(1, N + 1)\n",
+    "    abs_error = np.abs(run_mean - E_S)\n",
+    "    ax.plot(n_vals, abs_error, color=colors[i], lw=0.4, alpha=0.5)\n",
+    "\n",
+    "# Theoretical O(1/sqrt(n)) line\n",
+    "theoretical_error = SD_S / np.sqrt(n_vals)\n",
+    "ax.plot(n_vals, theoretical_error, \"r--\", lw=2,\n",
+    "        label=r\"$\\sigma / \\sqrt{n}$ (theoretical SE)\")\n",
+    "\n",
+    "ax.set_xscale(\"log\")\n",
+    "ax.set_yscale(\"log\")\n",
+    "ax.set_xlabel(\"Number of samples $n$ (log scale)\")\n",
+    "ax.set_ylabel(r\"$|\\bar{X}_n - E[X]|$ (log scale)\")\n",
+    "ax.set_title(r\"Convergence Rate: $O(1/\\sqrt{n})$\")\n",
+    "ax.legend()\n",
+    "plt.tight_layout()\n",
+    "plt.savefig(\"../figures/lln_convergence_loglog.png\", dpi=150,\n",
+    "            bbox_inches=\"tight\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Full Budget Model Convergence\n",
+    "\n",
+    "We now demonstrate convergence on the **full budget model** (not just salaries)\n",
+    "to verify that the LLN applies to the composite cost $X_{\\text{total}}$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Model parameters\n",
+    "n_employees = 50\n",
+    "beta = 1.80\n",
+    "lambda_h = 5\n",
+    "r_ot = 80\n",
+    "lambda_I = 3\n",
+    "mu_I, sigma_I = 10.5, 0.5\n",
+    "\n",
+    "# Analytical E[X_total] from Phase 1\n",
+    "E_T1 = n_employees * beta * 12 * E_S\n",
+    "E_C = np.exp(mu_I + sigma_I**2 / 2)\n",
+    "E_T2 = n_employees * r_ot * 12 * lambda_h\n",
+    "E_T3 = lambda_I * E_C\n",
+    "E_total = E_T1 + E_T2 + E_T3\n",
+    "\n",
+    "print(f\"Analytical E[X_total] = R$ {E_total:,.2f}\")\n",
+    "\n",
+    "\n",
+    "def simulate_one_year(rng: np.random.Generator) -> float:\n",
+    "    \"\"\"Simulate one year of the budget model.\"\"\"\n",
+    "    salaries = rng.lognormal(mean=mu_s, sigma=sigma_s, size=n_employees)\n",
+    "    term1 = np.sum(salaries) * beta * 12\n",
+    "\n",
+    "    overtime_hours = rng.poisson(lam=lambda_h, size=(n_employees, 12))\n",
+    "    term2 = np.sum(overtime_hours) * r_ot\n",
+    "\n",
+    "    n_incidents = rng.poisson(lam=lambda_I)\n",
+    "    term3 = (\n",
+    "        np.sum(rng.lognormal(mean=mu_I, sigma=sigma_I, size=n_incidents))\n",
+    "        if n_incidents > 0\n",
+    "        else 0.0\n",
+    "    )\n",
+    "\n",
+    "    return term1 + term2 + term3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N_budget = 5_000\n",
+    "n_budget_runs = 5\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(12, 6))\n",
+    "\n",
+    "for i in range(n_budget_runs):\n",
+    "    sim_rng = np.random.default_rng(seed=200 + i)\n",
+    "    costs = np.array([simulate_one_year(sim_rng) for _ in range(N_budget)])\n",
+    "    budget_running_mean = np.cumsum(costs) / np.arange(1, N_budget + 1)\n",
+    "    ax.plot(np.arange(1, N_budget + 1), budget_running_mean / 1e6,\n",
+    "            lw=0.8, alpha=0.7)\n",
+    "\n",
+    "ax.axhline(E_total / 1e6, color=\"red\", ls=\"--\", lw=2,\n",
+    "           label=f\"Analytical $E[X]$ = R$ {E_total/1e6:.2f}M\")\n",
+    "\n",
+    "ax.set_xlabel(\"Number of simulations $N$\")\n",
+    "ax.set_ylabel(\"Running mean (R$ millions)\")\n",
+    "ax.set_title(f\"Budget Model — LLN Convergence ({n_budget_runs} runs)\")\n",
+    "ax.legend(loc=\"upper right\")\n",
+    "ax.set_xlim(1, N_budget)\n",
+    "plt.tight_layout()\n",
+    "plt.savefig(\"../figures/lln_convergence_budget.png\", dpi=150,\n",
+    "            bbox_inches=\"tight\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Chebyshev Bound vs Empirical Violation Rate\n",
+    "\n",
+    "The Chebyshev bound says $P(|\\bar{X}_N - \\mu| \\geq \\epsilon) \\leq \\sigma^2/(N\\epsilon^2)$.\n",
+    "How conservative is this bound in practice?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Empirical test: for different N, run many experiments and count violations\n",
+    "epsilon = 500  # R$ 500 tolerance\n",
+    "n_experiments = 10_000\n",
+    "N_values = [50, 100, 200, 500, 1_000, 2_000, 5_000]\n",
+    "\n",
+    "print(f\"{'N':>6}  {'Chebyshev bound':>16}  {'Empirical rate':>15}  {'Ratio':>6}\")\n",
+    "print(\"-\" * 60)\n",
+    "\n",
+    "for N_test in N_values:\n",
+    "    chebyshev_bound = Var_S / (N_test * epsilon**2)\n",
+    "    chebyshev_bound = min(chebyshev_bound, 1.0)  # cap at 1\n",
+    "\n",
+    "    violations = 0\n",
+    "    for _ in range(n_experiments):\n",
+    "        test_rng = np.random.default_rng()\n",
+    "        test_samples = test_rng.lognormal(mean=mu_s, sigma=sigma_s, size=N_test)\n",
+    "        sample_mean = test_samples.mean()\n",
+    "        if abs(sample_mean - E_S) >= epsilon:\n",
+    "            violations += 1\n",
+    "\n",
+    "    empirical_rate = violations / n_experiments\n",
+    "    ratio = chebyshev_bound / empirical_rate if empirical_rate > 0 else float('inf')\n",
+    "    print(f\"{N_test:>6}  {chebyshev_bound:>16.6f}  {empirical_rate:>15.6f}  {ratio:>6.1f}x\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Key Takeaways\n",
+    "\n",
+    "1. **The LLN works.** All runs converge to $E[X]$: high variability at small $N$,\n",
+    "   tight clustering at large $N$.\n",
+    "\n",
+    "2. **The convergence rate is $O(1/\\sqrt{N})$.** On a log-log plot, the absolute\n",
+    "   error tracks the theoretical $\\sigma/\\sqrt{n}$ line.\n",
+    "\n",
+    "3. **Chebyshev bounds are conservative.** The theoretical bound is typically\n",
+    "   5–20x looser than the empirical violation rate. This motivates the CLT\n",
+    "   (Phase 3), which gives much tighter bounds by exploiting normality.\n",
+    "\n",
+    "4. **The full budget model also converges.** The LLN applies to any random\n",
+    "   variable with finite mean — including the composite budget cost.\n",
+    "\n",
+    "### What comes next (Phase 3)\n",
+    "\n",
+    "The LLN tells us **that** the estimate converges. The CLT will tell us\n",
+    "**how fast** and give us proper confidence intervals."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notes/phase2-convergence.md
+++ b/notes/phase2-convergence.md
@@ -1,0 +1,418 @@
+# Phase 2 — Convergence Theorems
+
+## Overview
+
+This phase establishes the theoretical backbone of Monte Carlo simulation:
+the **Law of Large Numbers**. The proof chain is:
+
+$$
+\text{Markov's inequality} \;\longrightarrow\; \text{Chebyshev's inequality} \;\longrightarrow\; \text{Weak Law of Large Numbers}
+$$
+
+Each link in this chain is derived from scratch. The Strong Law of Large
+Numbers is stated with intuition and a proof sketch.
+
+---
+
+## 1. Markov's Inequality
+
+### Statement
+
+**Theorem 1.1 (Markov's Inequality).** Let $X$ be a non-negative random
+variable with finite expectation. Then for any $a > 0$:
+
+$$
+P(X \geq a) \leq \frac{E[X]}{a}
+$$
+
+### Proof
+
+Since $X \geq 0$, we can write:
+
+$$
+E[X] = \int_0^{\infty} x \, f_X(x) \, dx
+$$
+
+Split the integral at $a$:
+
+$$
+E[X] = \int_0^{a} x \, f_X(x) \, dx + \int_a^{\infty} x \, f_X(x) \, dx
+$$
+
+The first integral is non-negative (since $x \geq 0$ and $f_X(x) \geq 0$), so:
+
+$$
+E[X] \geq \int_a^{\infty} x \, f_X(x) \, dx
+$$
+
+In the region $x \geq a$, we have $x \geq a$, so:
+
+$$
+\int_a^{\infty} x \, f_X(x) \, dx \geq \int_a^{\infty} a \, f_X(x) \, dx = a \int_a^{\infty} f_X(x) \, dx = a \, P(X \geq a)
+$$
+
+Combining:
+
+$$
+E[X] \geq a \, P(X \geq a)
+$$
+
+$$
+P(X \geq a) \leq \frac{E[X]}{a} \qquad \blacksquare
+$$
+
+### Numerical Example
+
+Let $S \sim \text{LogNormal}(9.2, 0.09)$ represent a monthly salary with
+$E[S] \approx 10{,}362$.
+
+**Question:** What is the upper bound on the probability that a salary exceeds
+R\$ 30,000?
+
+By Markov:
+
+$$
+P(S \geq 30{,}000) \leq \frac{E[S]}{30{,}000} = \frac{10{,}362}{30{,}000} \approx 0.345
+$$
+
+The true probability (computed from the LogNormal CDF) is approximately 0.018.
+Markov gives a loose but universally valid bound — it uses only the mean,
+no information about the distribution's shape.
+
+### Remark on Generality
+
+Markov's inequality is powerful precisely because it is weak: it requires
+only $E[X] < \infty$ and $X \geq 0$. No distributional assumptions are needed.
+This generality is what makes it the foundation for Chebyshev and the LLN.
+
+---
+
+## 2. Chebyshev's Inequality
+
+### Statement
+
+**Theorem 2.1 (Chebyshev's Inequality).** Let $X$ be a random variable with
+finite mean $\mu = E[X]$ and finite variance $\sigma^2 = \text{Var}(X)$. Then
+for any $\epsilon > 0$:
+
+$$
+P(|X - \mu| \geq \epsilon) \leq \frac{\sigma^2}{\epsilon^2}
+$$
+
+Equivalently, setting $\epsilon = k\sigma$ for $k > 0$:
+
+$$
+P(|X - \mu| \geq k\sigma) \leq \frac{1}{k^2}
+$$
+
+### Proof (as a Corollary of Markov)
+
+Define $Y = (X - \mu)^2$. Note that:
+
+- $Y \geq 0$ (it is a squared quantity)
+- $E[Y] = E[(X - \mu)^2] = \sigma^2$
+
+The event $\{|X - \mu| \geq \epsilon\}$ is equivalent to
+$\{(X - \mu)^2 \geq \epsilon^2\}$, which is $\{Y \geq \epsilon^2\}$.
+
+Apply Markov's inequality to $Y$ with threshold $a = \epsilon^2$:
+
+$$
+P(Y \geq \epsilon^2) \leq \frac{E[Y]}{\epsilon^2}
+$$
+
+$$
+P(|X - \mu| \geq \epsilon) \leq \frac{\sigma^2}{\epsilon^2} \qquad \blacksquare
+$$
+
+### Numerical Example
+
+Consider the total budget cost with $E[X_{\text{total}}] \approx 11{,}554{,}495$
+and $\text{SD}(X_{\text{total}}) \approx 492{,}747$ (from Phase 1).
+
+**Question:** What is the upper bound on the probability that the budget
+deviates from its expected value by more than R\$ 1,000,000?
+
+$$
+P(|X_{\text{total}} - 11{,}554{,}495| \geq 1{,}000{,}000) \leq \frac{(492{,}747)^2}{(1{,}000{,}000)^2} = \frac{2.428 \times 10^{11}}{10^{12}} \approx 0.243
+$$
+
+With $k\sigma$ form: $\epsilon = 1{,}000{,}000 \approx 2.03\sigma$, so
+$P \leq 1/(2.03)^2 \approx 0.243$.
+
+**Interpretation:** Chebyshev guarantees that at most 24.3% of budget outcomes
+deviate from the mean by more than R\$ 1M. The bound uses only the mean and
+variance — no distributional assumptions.
+
+### Comparison of Bounds
+
+| Bound | Information Used | Tightness |
+|-------|-----------------|-----------|
+| Markov | Mean only | Very loose |
+| Chebyshev | Mean + variance | Moderate |
+| CLT (Phase 3) | Mean + variance + normality | Tight |
+
+---
+
+## 3. Weak Law of Large Numbers
+
+### Setup
+
+Let $X_1, X_2, \ldots, X_n$ be **independent and identically distributed (i.i.d.)**
+random variables with:
+
+- $E[X_i] = \mu$ (finite)
+- $\text{Var}(X_i) = \sigma^2$ (finite)
+
+Define the **sample mean**:
+
+$$
+\bar{X}_n = \frac{1}{n} \sum_{i=1}^n X_i
+$$
+
+### Statement
+
+**Theorem 3.1 (Weak Law of Large Numbers).** Under the conditions above:
+
+$$
+\bar{X}_n \xrightarrow{P} \mu \quad \text{as } n \to \infty
+$$
+
+That is, for every $\epsilon > 0$:
+
+$$
+\lim_{n \to \infty} P(|\bar{X}_n - \mu| \geq \epsilon) = 0
+$$
+
+### Proof (via Chebyshev)
+
+**Step 1: Compute $E[\bar{X}_n]$.**
+
+By linearity of expectation:
+
+$$
+E[\bar{X}_n] = E\left[\frac{1}{n}\sum_{i=1}^n X_i\right] = \frac{1}{n}\sum_{i=1}^n E[X_i] = \frac{1}{n} \cdot n\mu = \mu
+$$
+
+So $\bar{X}_n$ is an **unbiased estimator** of $\mu$.
+
+**Step 2: Compute $\text{Var}(\bar{X}_n)$.**
+
+Since $X_i$ are independent:
+
+$$
+\text{Var}(\bar{X}_n) = \text{Var}\left(\frac{1}{n}\sum_{i=1}^n X_i\right) = \frac{1}{n^2}\sum_{i=1}^n \text{Var}(X_i) = \frac{1}{n^2} \cdot n\sigma^2 = \frac{\sigma^2}{n}
+$$
+
+**Step 3: Apply Chebyshev's inequality to $\bar{X}_n$.**
+
+For any $\epsilon > 0$:
+
+$$
+P(|\bar{X}_n - \mu| \geq \epsilon) \leq \frac{\text{Var}(\bar{X}_n)}{\epsilon^2} = \frac{\sigma^2}{n\epsilon^2}
+$$
+
+**Step 4: Take the limit.**
+
+$$
+\lim_{n \to \infty} P(|\bar{X}_n - \mu| \geq \epsilon) \leq \lim_{n \to \infty} \frac{\sigma^2}{n\epsilon^2} = 0
+$$
+
+Since probabilities are non-negative:
+
+$$
+\lim_{n \to \infty} P(|\bar{X}_n - \mu| \geq \epsilon) = 0 \qquad \blacksquare
+$$
+
+### Numerical Example
+
+For monthly salaries $S_i \sim \text{LogNormal}(9.2, 0.09)$ with
+$E[S_i] \approx 10{,}362$ and $\text{Var}(S_i) \approx 10{,}117{,}947$:
+
+**Question:** If we average $N = 1{,}000$ salary draws, what is the Chebyshev
+bound on the probability that $\bar{S}_N$ differs from $E[S]$ by more than
+R\$ 500?
+
+$$
+P(|\bar{S}_N - 10{,}362| \geq 500) \leq \frac{10{,}117{,}947}{1{,}000 \times 500^2} = \frac{10{,}117{,}947}{250{,}000{,}000} \approx 0.0405
+$$
+
+With 1,000 samples, Chebyshev guarantees at most a 4.05% chance that the
+sample mean deviates from the true mean by more than R\$ 500.
+
+### Interpretation for Monte Carlo
+
+The WLLN says: **the sample mean of $N$ simulated budgets converges to
+$E[X_{\text{total}}]$ as $N \to \infty$.**
+
+More concretely:
+
+1. Each simulation produces one sample $X_i$ from the budget cost distribution.
+2. The average of $N$ simulations, $\bar{X}_N$, is our Monte Carlo estimate.
+3. The WLLN guarantees that this estimate converges to the true expected cost.
+4. The rate of convergence is controlled by $\sigma^2 / (N\epsilon^2)$ — more
+   samples or larger tolerance both make the bound smaller.
+
+This is the fundamental theorem that justifies Monte Carlo estimation.
+Without it, averaging random simulations would be nothing more than numerology.
+
+---
+
+## 4. Strong Law of Large Numbers
+
+### Statement
+
+**Theorem 4.1 (Strong Law of Large Numbers — Kolmogorov).** Let $X_1, X_2, \ldots$
+be i.i.d. random variables with $E[|X_i|] < \infty$ and $E[X_i] = \mu$. Then:
+
+$$
+P\left(\lim_{n \to \infty} \bar{X}_n = \mu\right) = 1
+$$
+
+That is, $\bar{X}_n \xrightarrow{a.s.} \mu$ (almost sure convergence).
+
+### Convergence Modes: In Probability vs Almost Sure
+
+The key difference between the Weak and Strong LLN is the **mode of convergence**:
+
+| Mode | Notation | Meaning |
+|------|----------|---------|
+| In probability | $\bar{X}_n \xrightarrow{P} \mu$ | For every fixed $\epsilon > 0$, $P(\|\bar{X}_n - \mu\| \geq \epsilon) \to 0$ |
+| Almost sure | $\bar{X}_n \xrightarrow{a.s.} \mu$ | The set of $\omega$ where $\bar{X}_n(\omega) \not\to \mu$ has probability zero |
+
+**Analogy.** Convergence in probability says: "for any snapshot in time, the
+sample mean is probably close to $\mu$." Almost sure convergence says:
+"the entire trajectory of $\bar{X}_n$ eventually settles at $\mu$, with no
+exceptions except on a set of probability zero."
+
+Almost sure convergence is strictly stronger:
+
+$$
+\bar{X}_n \xrightarrow{a.s.} \mu \implies \bar{X}_n \xrightarrow{P} \mu
+$$
+
+The converse is false in general.
+
+### Intuition for the Proof
+
+The full proof of the SLLN (e.g., Kolmogorov's proof) relies on tools from
+measure theory, particularly:
+
+1. **Borel-Cantelli Lemma:** If $\sum_n P(A_n) < \infty$, then
+   $P(\limsup_n A_n) = 0$ — that is, only finitely many of the events $A_n$
+   occur, almost surely.
+
+2. **Fourth moment bound:** For i.i.d. variables with finite fourth moment
+   ($E[X^4] < \infty$), one can show $\sum_n P(|\bar{X}_n - \mu| \geq \epsilon) < \infty$
+   by bounding $E[(\bar{X}_n - \mu)^4]$ and applying Markov's inequality.
+
+3. **Kronecker's lemma + truncation:** For the general case (only
+   $E[|X|] < \infty$ required), the proof uses truncation arguments and
+   Kronecker's lemma to handle variables without finite variance.
+
+**Why we state but don't fully prove:** The SLLN requires measure-theoretic
+machinery (Borel-Cantelli, almost sure convergence) that is beyond the scope
+of this article. The WLLN proof via Chebyshev is elementary and sufficient
+to justify Monte Carlo — the SLLN is the stronger guarantee that "the
+simulation will eventually get the right answer, period."
+
+### Proof Sketch (Fourth Moment Version)
+
+Assume $E[X^4] < \infty$ in addition to i.i.d. with mean $\mu$ and
+variance $\sigma^2$.
+
+**Step 1.** Compute $E[(\bar{X}_n - \mu)^4]$.
+
+Let $Y_i = X_i - \mu$, so $E[Y_i] = 0$. Then:
+
+$$
+E\left[\left(\frac{1}{n}\sum Y_i\right)^4\right] = \frac{1}{n^4} E\left[\left(\sum Y_i\right)^4\right]
+$$
+
+Expanding $(\sum Y_i)^4$ and using independence ($E[Y_i Y_j Y_k Y_l] = 0$
+unless indices are paired), the dominant terms give:
+
+$$
+E[(\bar{X}_n - \mu)^4] = O\left(\frac{1}{n^2}\right)
+$$
+
+**Step 2.** Apply Markov's inequality with $Y = (\bar{X}_n - \mu)^4$:
+
+$$
+P(|\bar{X}_n - \mu| \geq \epsilon) = P((\bar{X}_n - \mu)^4 \geq \epsilon^4) \leq \frac{E[(\bar{X}_n - \mu)^4]}{\epsilon^4} = O\left(\frac{1}{n^2}\right)
+$$
+
+**Step 3.** Since $\sum_{n=1}^{\infty} 1/n^2 = \pi^2/6 < \infty$, by
+Borel-Cantelli:
+
+$$
+P(\limsup_n \{|\bar{X}_n - \mu| \geq \epsilon\}) = 0
+$$
+
+This means: almost surely, only finitely many of the events
+$\{|\bar{X}_n - \mu| \geq \epsilon\}$ occur. Since this holds for every
+$\epsilon > 0$, we get $\bar{X}_n \to \mu$ almost surely. $\blacksquare$
+
+### Relevance to Monte Carlo
+
+For our budget simulation:
+
+- **WLLN guarantees:** "With enough simulations, the Monte Carlo estimate
+  $\bar{X}_N$ is probably close to $E[X_{\text{total}}]$."
+
+- **SLLN guarantees:** "The Monte Carlo estimate $\bar{X}_N$ **will** converge
+  to $E[X_{\text{total}}]$ — not just probably, but with certainty (up to a
+  measure-zero set)."
+
+In practice, the SLLN assures us that Monte Carlo is not a gamble: given enough
+computational budget, the answer is correct. The remaining question — "how
+close is the estimate for a given $N$?" — is answered by the Central Limit
+Theorem (Phase 3).
+
+---
+
+## 5. Chebyshev Bounds for Monte Carlo
+
+### Deriving the Bound
+
+From the WLLN proof, we established:
+
+$$
+P(|\bar{X}_N - \mu| \geq \epsilon) \leq \frac{\sigma^2}{N \epsilon^2}
+$$
+
+We can invert this to find the **minimum $N$** for a desired guarantee.
+Given a tolerance $\epsilon$ and a confidence level $1 - \alpha$ (i.e., we want
+$P(|\bar{X}_N - \mu| \geq \epsilon) \leq \alpha$):
+
+$$
+\frac{\sigma^2}{N \epsilon^2} \leq \alpha \implies N \geq \frac{\sigma^2}{\alpha \epsilon^2}
+$$
+
+### Example: Budget Simulation
+
+For the total budget with $\sigma \approx 492{,}747$:
+
+**Question:** How many simulations are needed so that the Chebyshev bound
+guarantees $P(|\bar{X}_N - E[X]| \geq 100{,}000) \leq 0.05$?
+
+$$
+N \geq \frac{(492{,}747)^2}{0.05 \times (100{,}000)^2} = \frac{2.428 \times 10^{11}}{5 \times 10^{8}} \approx 486
+$$
+
+According to Chebyshev, we need at least 486 simulations. The CLT (Phase 3)
+will give a much tighter answer.
+
+### Chebyshev Confidence Band
+
+For a running simulation with $n$ samples so far, the Chebyshev bound defines
+a confidence band around $\mu$:
+
+$$
+\mu \in \left[\bar{X}_n - \frac{\sigma}{\sqrt{n\alpha}}, \; \bar{X}_n + \frac{\sigma}{\sqrt{n\alpha}}\right]
+$$
+
+with probability at least $1 - \alpha$.
+
+This band shrinks as $O(1/\sqrt{n})$, visually demonstrating convergence.
+The convergence notebook overlays this band on the running mean plot.


### PR DESCRIPTION
## Summary

Phase 2 — Convergence Theorems: theory notes with complete proof chain
(Markov → Chebyshev → WLLN → SLLN), exercises for paper work, and
interactive notebook demonstrating LLN convergence with Chebyshev bounds.

- Markov's inequality proved from integral definition
- Chebyshev derived as corollary of Markov on (X − μ)²
- WLLN proved in 4 steps via Chebyshev
- SLLN stated with proof sketch (fourth moment + Borel-Cantelli)
- Notebook: 10 independent runs, log-log convergence rate, full budget model convergence, Chebyshev bound vs empirical violation rate

Closes #6, #7

## Type of Change

- [x] New feature (`feat`)

## Checklist

- [x] Code runs without errors
- [x] Documentation updated
- [x] No hardcoded paths or secrets

## Mathematical Validation

- [x] Derivations reviewed for correctness
- [x] Numerical examples match code output