### PR TITLE
refactor(docs): generalize framing from IT-specific to generic budget modelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 # Why Your Budget Never Hits the Exact Number
 
-## Monte Carlo Simulation for IT Budget Planning — from Point Estimates to Probability Distributions
+## Monte Carlo Simulation for Stochastic Budget Modelling — from Point Estimates to Probability Distributions
 
 Point estimates ignore uncertainty. This project uses Monte Carlo simulation to
-approximate the full distribution of outcomes, enabling interval-based forecasts.
-Grounded in the Law of Large Numbers and Central Limit Theorem.
+approximate the full distribution of budget outcomes, enabling interval-based
+forecasts. Grounded in the Law of Large Numbers and Central Limit Theorem.
+The framework is general; IT headcount planning serves as the primary case study.
 
 ## About
 
 A **portfolio-grade technical article** that replaces traditional point-estimate
 budgeting with stochastic modelling via Monte Carlo simulation. The article
-derives the mathematical foundations from first principles and applies them to
-a generic IT headcount budget model.
+derives the mathematical foundations from first principles and demonstrates the
+approach on an IT headcount budget — one instantiation of a general template
+that applies to any budget with proportional costs, fixed charges, and rare
+disruptive events.
 
 ### What This Project Is
 

--- a/article/monte-carlo-budget-pt.md
+++ b/article/monte-carlo-budget-pt.md
@@ -1,37 +1,47 @@
 # Por Que o Seu Orcamento Nunca Crava o Valor Exato
 
-## Simulacao Monte Carlo para Planejamento Orcamentario de TI — de Estimativas Pontuais a Distribuicoes de Probabilidade
+## Simulacao Monte Carlo para Planejamento Orcamentario — de Estimativas Pontuais a Distribuicoes de Probabilidade
 
 ---
 
 ## 1. Introducao
 
-Seu CFO pede o orcamento de headcount de TI para o proximo ano. Voce abre uma planilha, multiplica o numero de funcionarios pelo salario medio, soma o multiplicador de beneficios, joga uma estimativa de horas extras, arredonda para cima por conta de incidentes — e entrega um numero. Um unico numero. R$ 11,5 milhoes.
+Alguem pede o orcamento do proximo ano. Voce abre uma planilha, multiplica quantidades por custos unitarios, adiciona contingencias, arredonda um pouco para cima — e entrega um numero. Um unico numero.
 
 Mas e se esse numero for apenas uma amostra de uma distribuicao que voce nunca viu?
 
-Toda organizacao que gerencia orcamentos de headcount — salarios, beneficios, horas extras, custos nao planejados — enfrenta o mesmo ritual. O time produz uma estimativa pontual, a lideranca aprova, e o ano transcorre. Meses depois, durante uma revisao de FYF (Forecast Year-end Financial), os gastos reais divergem da previsao. O time ajusta. Outra revisao. Outro ajuste. No final do ano, o numero original parece pouco mais que um chute educado.
+Toda organizacao que gerencia orcamentos — custos de headcount, despesas de projetos, procurement, marketing — enfrenta o mesmo ritual. O time produz uma estimativa pontual, a lideranca aprova, e o periodo transcorre. Meses depois, durante uma revisao periodica do forecast, os gastos reais divergem. O time ajusta. Outra revisao. Outro ajuste. No final do periodo, o numero original parece pouco mais que um chute educado.
 
-O problema nao e que a estimativa estava errada. O problema e que um numero unico nao carrega informacao sobre sua propria incerteza. R$ 11,5M era uma estimativa conservadora? Otimista? Qual a probabilidade de ultrapassarmos R$ 12,5M? A estimativa pontual nao consegue responder essas perguntas — porque ela descarta tudo exceto o centro da distribuicao.
+O problema nao e que a estimativa estava errada. O problema e que um numero unico nao carrega informacao sobre sua propria incerteza. Era uma estimativa conservadora? Otimista? Qual a probabilidade de ultrapassar o teto aprovado? A estimativa pontual nao responde — porque descarta tudo exceto o centro da distribuicao.
 
-Este artigo substitui o numero unico por uma **distribuicao de probabilidade**. Usando simulacao Monte Carlo fundamentada na Lei dos Grandes Numeros e no Teorema Central do Limite, transformamos "esperamos gastar R$ 11,5M" em "temos 90% de confianca de que os gastos ficarao entre R$ 10,7M e R$ 12,4M, com 7% de probabilidade de ultrapassar o teto de R$ 12,5M."
+Este artigo substitui o numero unico por uma **distribuicao de probabilidade**. Usando simulacao Monte Carlo fundamentada na Lei dos Grandes Numeros e no Teorema Central do Limite, transformamos "esperamos gastar R$ 11,5M" em "temos 90% de confianca de que os gastos ficarao entre R$ 10,7M e R$ 12,4M, com 7% de probabilidade de ultrapassar o teto."
 
-A jornada matematica segue quatro estagios: formalizamos os componentes do orcamento como variaveis aleatorias (Secao 3), provamos que a media das simulacoes converge para a resposta verdadeira (Secao 4), quantificamos o erro da simulacao (Secao 5) e implementamos o estimador com tecnicas de reducao de variancia (Secoes 6-7). A Secao 9 valida tudo experimentalmente.
+A abordagem e **geral**: aplica-se a qualquer orcamento que possa ser decomposto em componentes estocasticos — headcount, projetos, procurement, licenciamento, infraestrutura. Ilustramos com um orcamento de headcount de TI (salarios, beneficios, horas extras, incidentes) como estudo de caso concreto, mas o framework matematico se transfere diretamente para qualquer dominio.
+
+A jornada segue quatro estagios: formalizamos componentes orcamentarios como variaveis aleatorias (Secao 3), provamos que a media das simulacoes converge para a resposta verdadeira (Secao 4), quantificamos o erro da simulacao (Secao 5), e implementamos o estimador com tecnicas de reducao de variancia (Secoes 6-7). A Secao 9 valida tudo experimentalmente.
 
 ### Notacao
 
 | Simbolo | Significado |
 |---------|-------------|
+| $X_{\text{total}}$ | Custo orcamentario total (variavel aleatoria) |
+| $X_k$ | Custo do componente $k$ |
+| $n$ | Numero de unidades (headcount, itens, etc.) |
+| $\bar{X}_N$ | Media amostral de $N$ simulacoes |
+| $\hat{\theta}_N$ | Estimador Monte Carlo |
+| $\sigma$ | Desvio padrao da distribuicao de custos |
+| $z_{\alpha/2}$ | Quantil Normal para nivel de confianca $1-\alpha$ |
+
+**Notacao do estudo de caso** (headcount TI):
+
+| Simbolo | Significado |
+|---------|-------------|
 | $S_i$ | Salario mensal do funcionario $i$ |
-| $\beta$ | Multiplicador de beneficios (encargos) |
-| $n$ | Numero de funcionarios (headcount) |
+| $\beta$ | Multiplicador de beneficios |
 | $H_i$ | Horas extras por funcionario por mes |
 | $r_{ot}$ | Valor da hora extra |
 | $I$ | Numero de incidentes graves por ano |
 | $C_j$ | Custo do incidente $j$ |
-| $X_{\text{total}}$ | Custo orcamentario total anual |
-| $\bar{X}_N$ | Media amostral de $N$ simulacoes |
-| $\hat{\theta}_N$ | Estimador Monte Carlo |
 
 ---
 
@@ -40,93 +50,105 @@ A jornada matematica segue quatro estagios: formalizamos os componentes do orcam
 Uma estimativa pontual e um valor unico usado para aproximar um parametro desconhecido. No planejamento orcamentario, ela toma a forma:
 
 $$
-\hat{X} = n \times \bar{S} \times \beta \times 12 + \text{horas extras} + \text{incidentes}
+\hat{X} = \sum_{k} (\text{quantidade}_k \times \text{custo unitario}_k) + \text{contingencia}
 $$
 
-onde $\bar{S}$ e o salario medio e todo o resto e constante. O resultado e um numero — digamos, R$ 11.554.473.
-
-Mas esse numero e $E[X_{\text{total}}]$: o valor esperado de uma variavel aleatoria. Ele nos diz o centro da distribuicao. O que ele descarta e todo o resto:
+O resultado e um numero — digamos, R$ 11,5 milhoes. Mas esse numero e $E[X_{\text{total}}]$: o valor esperado de uma variavel aleatoria. Ele nos diz o centro da distribuicao. O que descarta e todo o resto:
 
 - **Variancia:** Quao dispersos sao os resultados possiveis?
-- **Assimetria:** A distribuicao e simetrica, ou custos podem ser puxados para cima por alguns salarios extremos?
-- **Risco de cauda:** Qual a probabilidade de ultrapassar o orcamento aprovado?
-- **Confianca:** Quao certos estamos de que o custo verdadeiro esta dentro de ±R$ 500K da nossa estimativa?
+- **Assimetria:** A distribuicao e simetrica, ou custos podem ser puxados para cima por eventos extremos?
+- **Risco de cauda:** Qual a probabilidade de ultrapassar o teto aprovado?
+- **Confianca:** Quao certos estamos de que o custo verdadeiro esta dentro de ±5% da estimativa?
 
 Em termos formais, a estimativa pontual nos da $E[X]$ mas nao a distribuicao $F_X$. A simulacao Monte Carlo recupera $F_X$ — o quadro completo.
 
+### O Padrao Geral
+
+Qualquer orcamento com componentes incertos pode ser escrito como:
+
+$$
+X_{\text{total}} = \sum_{k=1}^{K} g_k(\mathbf{Z}_k)
+$$
+
+onde $g_k$ e uma funcao de custo para o componente $k$ e $\mathbf{Z}_k$ e um vetor de entradas aleatorias. A estimativa pontual colapsa cada $g_k$ para seu valor esperado; Monte Carlo preserva a distribuicao conjunta completa.
+
 ---
 
-## 3. Variaveis Aleatorias Disfarcadas
+## 3. Componentes Orcamentarios como Variaveis Aleatorias
 
-Cada componente do orcamento e uma variavel aleatoria. Trata-los como constantes e uma escolha de modelagem que descarta informacao.
+Cada componente de um orcamento e potencialmente uma variavel aleatoria. Trata-los como constantes e uma escolha de modelagem que descarta informacao. O insight chave: **identifique quais componentes carregam incerteza significativa, modele-os probabilisticamente, e mantenha o restante deterministico.**
 
-### Salarios: LogNormal
+### A Estrutura Geral
 
-Salarios em um time de TI com senioridades mistas sao estritamente positivos e assimetricos a direita: a maioria dos funcionarios ganha perto da mediana, mas alguns engenheiros senior ou gestores ganham significativamente mais. A distribuicao LogNormal captura isso:
+Um modelo orcamentario estocastico tem tres tipos de componentes:
 
-$$
-S_i \sim \text{LogNormal}(\mu_s, \sigma_s^2)
-$$
-
-Com parametros $\mu_s = 9,2$ e $\sigma_s = 0,3$, o salario mensal esperado e:
+1. **Custos proporcionais:** quantidade × taxa, onde um ou ambos podem ser aleatorios
+2. **Custos fixos com incerteza:** estrutura conhecida mas magnitude incerta
+3. **Eventos raros:** contagem aleatoria de ocorrencias × custo aleatorio por evento (processo composto)
 
 $$
-E[S_i] = e^{\mu_s + \sigma_s^2/2} = e^{9,245} \approx R\$ \, 10.362
+X_{\text{total}} = \underbrace{\sum_{i=1}^{n} f(Z_i)}_{\text{proporcional}} + \underbrace{\text{componentes fixos}}_{\text{deterministico}} + \underbrace{\sum_{j=1}^{N_{\text{eventos}}} C_j}_{\text{eventos raros}}
 $$
 
-A variancia e:
+### Estudo de Caso: Orcamento de Headcount de TI
+
+Instanciamos essa estrutura com um exemplo concreto — um time de TI com 50 pessoas:
+
+**Salarios (LogNormal).** Salarios sao estritamente positivos e assimetricos a direita:
 
 $$
-\text{Var}(S_i) = (e^{\sigma_s^2} - 1) \cdot e^{2\mu_s + \sigma_s^2} \approx 10.117.947
+S_i \sim \text{LogNormal}(\mu_s, \sigma_s^2), \quad \mu_s = 9{,}2, \; \sigma_s = 0{,}3
 $$
 
-### Horas Extras: Poisson
+$$
+E[S_i] = e^{\mu_s + \sigma_s^2/2} = e^{9{,}245} \approx R\$ \, 10.362
+$$
 
-Horas extras por funcionario por mes sao discretas, nao-negativas e relativamente raras — um ajuste natural para a distribuicao de Poisson:
+**Horas Extras (Poisson).** Discretas, nao-negativas, relativamente raras:
 
 $$
 H_i \sim \text{Poisson}(\lambda_h), \quad \lambda_h = 5
 $$
 
-Propriedade chave: para Poisson, $E[H_i] = \text{Var}(H_i) = \lambda_h$.
-
-### Incidentes: Poisson Composto
-
-Incidentes graves — indisponibilidades, falhas de seguranca, deployments emergenciais — ocorrem a uma taxa aleatoria com severidade aleatoria:
+**Incidentes (Poisson Composto).** Taxa aleatoria com severidade aleatoria:
 
 $$
 I \sim \text{Poisson}(\lambda_I), \quad C_j \sim \text{LogNormal}(\mu_I, \sigma_I^2)
 $$
 
-O custo total de incidentes e uma **soma aleatoria de variaveis aleatorias**: $\sum_{j=1}^I C_j$.
-
-### O Modelo de Custo Total
-
-Combinando todos os componentes:
+**Custo total:**
 
 $$
 X_{\text{total}} = \underbrace{\sum_{i=1}^{n} S_i \cdot \beta \cdot 12}_{\text{salarios + beneficios}} + \underbrace{\sum_{i=1}^{n} H_i \cdot r_{ot} \cdot 12}_{\text{horas extras}} + \underbrace{\sum_{j=1}^{I} C_j}_{\text{incidentes}}
 $$
 
-Usando linearidade da esperanca (que vale independentemente de correlacao):
-
-$$
-E[X_{\text{total}}] = n \cdot \beta \cdot 12 \cdot E[S_i] + n \cdot r_{ot} \cdot 12 \cdot E[H_i] + E[I] \cdot E[C_j]
-$$
-
-Com parametros padrao ($n = 50$, $\beta = 1,80$, $r_{ot} = 80$, $\lambda_I = 3$):
+Pela linearidade da esperanca:
 
 $$
 E[X_{\text{total}}] \approx 11.191.000 + 240.000 + 123.500 \approx R\$ \, 11.554.500
 $$
 
-O componente salarial domina com ~97% do total. Isso sera importante para reducao de variancia mais adiante.
+O componente salarial domina com ~97%. Esse padrao — um componente gerando a maior parte da variancia — e comum em diversos tipos de orcamento e sera importante para reducao de variancia.
+
+### Outras Instanciacoes
+
+A mesma estrutura se aplica a:
+
+| Tipo de Orcamento | Proporcional | Fixo | Eventos Raros |
+|-------------------|-------------|------|---------------|
+| **Headcount TI** | Salarios × headcount | Beneficios | Incidentes |
+| **Infra Cloud** | Uso × preco unitario | Instancias reservadas | Remediacao de indisponibilidades |
+| **Marketing** | Impressoes × CPC | Taxas de plataforma | Campanhas fracassadas |
+| **Construcao** | Materiais × quantidade | Alvaras, seguros | Atrasos climaticos, retrabalho |
+| **Projetos de P&D** | Horas × taxa × tamanho do time | Equipamentos | Mudancas de escopo |
+
+Em cada caso: identifique os componentes aleatorios, escolha distribuicoes, e simule.
 
 ---
 
 ## 4. A Media Vai Convergir? A Lei dos Grandes Numeros
 
-Se simularmos o orcamento 10.000 vezes e calcularmos a media dos resultados, essa media convergira para o verdadeiro $E[X_{\text{total}}]$? A Lei dos Grandes Numeros diz que sim.
+Se simularmos o orcamento 10.000 vezes e calcularmos a media, essa media convergira para o verdadeiro $E[X_{\text{total}}]$? A Lei dos Grandes Numeros diz que sim.
 
 ### Desigualdade de Chebyshev
 
@@ -136,30 +158,28 @@ $$
 P(|X - \mu| \geq \epsilon) \leq \frac{\sigma^2}{\epsilon^2}
 $$
 
-Derivada da desigualdade de Markov aplicada a $(X - \mu)^2$.
-
 ### A Lei Fraca dos Grandes Numeros
 
-Sejam $X_1, \ldots, X_N$ i.i.d. com media $\mu$ e variancia $\sigma^2$. A media amostral $\bar{X}_N = \frac{1}{N}\sum X_i$ satisfaz:
+Sejam $X_1, \ldots, X_N$ i.i.d. com media $\mu$ e variancia $\sigma^2$. A media amostral satisfaz:
 
 $$
 P(|\bar{X}_N - \mu| \geq \epsilon) \leq \frac{\sigma^2}{N\epsilon^2} \to 0 \quad \text{quando } N \to \infty
 $$
 
-**Demonstracao.** Como $E[\bar{X}_N] = \mu$ e $\text{Var}(\bar{X}_N) = \sigma^2/N$, aplicar Chebyshev a $\bar{X}_N$ da o resultado imediatamente. $\blacksquare$
+**Demonstracao.** Como $E[\bar{X}_N] = \mu$ e $\text{Var}(\bar{X}_N) = \sigma^2/N$, aplicar Chebyshev a $\bar{X}_N$ da o resultado. $\blacksquare$
 
-A Lei Forte dos Grandes Numeros oferece garantia ainda mais forte: $\bar{X}_N \to \mu$ quase certamente, significando que a convergencia ocorre com probabilidade 1.
+A Lei Forte garante convergencia quase certa (probabilidade 1).
 
-**Para Monte Carlo:** cada simulacao $X_i$ e um "ano possivel." A LGN garante que a media de $N$ anos simulados converge para o custo esperado verdadeiro. A Figura 1 demonstra isso visualmente.
+**Para Monte Carlo:** cada simulacao $X_i$ e um cenario possivel. A LGN garante que a media de $N$ cenarios converge para o custo esperado verdadeiro.
 
 ![Convergencia LGN](../figures/lln_convergence.png)
-*Figura 1: Dez execucoes independentes da media amostral convergindo para $E[S]$, com banda de confianca de Chebyshev a 95%.*
+*Figura 1: Dez execucoes independentes da media amostral convergindo para $E[X]$, com banda de Chebyshev a 95%.*
 
 ---
 
 ## 5. Quao Errados Podemos Estar? O Teorema Central do Limite
 
-A LGN nos diz que o estimador converge. O TCL nos diz **quao rapido** — e nos da intervalos de confianca.
+A LGN nos diz que converge. O TCL nos diz **quao rapido** — e da intervalos de confianca.
 
 ### Enunciado
 
@@ -171,42 +191,40 @@ $$
 
 ### Esboco da Demonstracao (via FGM)
 
-Defina $W_i = (X_i - \mu)/\sigma$ de modo que $E[W_i] = 0$ e $\text{Var}(W_i) = 1$. A soma padronizada e $Z_N = \frac{1}{\sqrt{N}}\sum W_i$. Sua FGM e:
+Defina $W_i = (X_i - \mu)/\sigma$. A soma padronizada $Z_N = \frac{1}{\sqrt{N}}\sum W_i$ tem FGM:
 
 $$
 M_{Z_N}(t) = \left[M_W\left(\frac{t}{\sqrt{N}}\right)\right]^N
 $$
 
-Expandindo $\log M_W(s) = s^2/2 + O(s^3)$ em Taylor e substituindo $s = t/\sqrt{N}$:
+Expandindo em Taylor: $\log M_W(s) = s^2/2 + O(s^3)$. Substituindo $s = t/\sqrt{N}$:
 
 $$
-\log M_{Z_N}(t) = N \cdot \left[\frac{t^2}{2N} + O\left(\frac{t^3}{N^{3/2}}\right)\right] = \frac{t^2}{2} + O\left(\frac{t^3}{\sqrt{N}}\right) \to \frac{t^2}{2}
+\log M_{Z_N}(t) = \frac{t^2}{2} + O\left(\frac{t^3}{\sqrt{N}}\right) \to \frac{t^2}{2}
 $$
 
-Como $e^{t^2/2}$ e a FGM de $N(0, 1)$, o teorema de unicidade da $Z_N \xrightarrow{d} N(0, 1)$. $\blacksquare$
+Como $e^{t^2/2}$ e a FGM de $N(0, 1)$, unicidade da $Z_N \xrightarrow{d} N(0, 1)$. $\blacksquare$
 
 ### Intervalos de Confianca
 
-Pelo TCL, o intervalo de confianca $(1-\alpha)$ para $\mu$ e:
+Pelo TCL, o IC $(1-\alpha)$ para $\mu$ e:
 
 $$
 \bar{X}_N \pm z_{\alpha/2} \cdot \frac{s_N}{\sqrt{N}}
 $$
 
-onde $s_N$ e o desvio padrao amostral e $z_{\alpha/2}$ e o quantil da Normal (1,96 para 95%).
-
 ### Escolhendo N
 
-Para obter um intervalo com semi-amplitude $\epsilon$:
+Para semi-amplitude $\epsilon$:
 
 $$
 N \geq \left(\frac{z_{\alpha/2} \cdot \sigma}{\epsilon}\right)^2
 $$
 
-Para nosso orcamento ($\sigma \approx 493K$, $\epsilon = 100K$, 95% de confianca): $N \geq (1,96 \times 493.000 / 100.000)^2 \approx 94$. O TCL e notavelmente eficiente.
+Para nosso estudo de caso ($\sigma \approx 493K$, $\epsilon = 100K$, 95%): $N \geq 94$.
 
-![Emergencia de Normalidade - TCL](../figures/clt_normality_emergence.png)
-*Figura 2: Conforme $n$ aumenta, a media padronizada de salarios LogNormal converge para $N(0,1)$.*
+![Emergencia de Normalidade](../figures/clt_normality_emergence.png)
+*Figura 2: Conforme $n$ aumenta, a media padronizada converge para $N(0,1)$.*
 
 ---
 
@@ -220,104 +238,92 @@ $$
 \hat{\theta}_N = \frac{1}{N} \sum_{i=1}^N g(X_i)
 $$
 
-onde cada $g(X_i)$ e o custo total de um ano simulado.
+onde cada $g(X_i)$ e o custo total de um cenario simulado.
 
 ### Propriedades
 
-**Nao-viesado.** $E[\hat{\theta}_N] = \frac{1}{N}\sum E[g(X_i)] = \theta$. O estimador nao tem vies sistematico.
+**Nao-viesado.** $E[\hat{\theta}_N] = \theta$.
 
-**Consistente.** Pela LGN Fraca: $\hat{\theta}_N \xrightarrow{P} \theta$. Mais simulacoes significa mais precisao.
+**Consistente.** $\hat{\theta}_N \xrightarrow{P} \theta$ (LGN).
 
-**Normalidade assintotica.** Pelo TCL: $\sqrt{N}(\hat{\theta}_N - \theta)/\sigma_g \xrightarrow{d} N(0, 1)$. Podemos construir intervalos de confianca.
+**Normalidade assintotica.** $\sqrt{N}(\hat{\theta}_N - \theta)/\sigma_g \xrightarrow{d} N(0, 1)$ (TCL).
 
-**Taxa de convergencia.** O erro padrao e $\text{EP} = \sigma_g / \sqrt{N}$, que decai como $O(1/\sqrt{N})$. Crucialmente, essa taxa e **independente da dimensao** de $X$ — diferente de metodos de integracao deterministica que sofrem da maldicao da dimensionalidade.
+**Taxa de convergencia.** $\text{EP} = \sigma_g / \sqrt{N}$, decaindo como $O(1/\sqrt{N})$. **Independente da dimensao** de $X$.
 
-### A Lei de Escala
+### Lei de Escala
 
-Reduzir pela metade a amplitude do IC requer 4× mais simulacoes. Ir de ±R$ 100K para ±R$ 50K significa quadruplicar $N$. Esse trade-off fundamental motiva a reducao de variancia.
+Reduzir a amplitude do IC pela metade requer 4× mais simulacoes.
 
 ### Erro Quadratico Medio
 
-Como o estimador e nao-viesado:
-
-$$
-\text{EQM}(\hat{\theta}_N) = \text{Var}(\hat{\theta}_N) = \frac{\sigma_g^2}{N}
-$$
+$\text{EQM}(\hat{\theta}_N) = \sigma_g^2 / N$ (estimador nao-viesado).
 
 ---
 
 ## 7. Tornando Mais Rapido: Reducao de Variancia
 
-A taxa $O(1/\sqrt{N})$ significa que precisao por forca bruta e cara. Tecnicas de reducao de variancia alcancam intervalos de confianca mais estreitos **para o mesmo custo computacional**.
+A taxa $O(1/\sqrt{N})$ significa que precisao por forca bruta e cara. Tecnicas de reducao de variancia alcancam ICs mais estreitos **para o mesmo custo computacional**.
 
 ### Variaveis de Controle
 
-Se conhecemos $E[h(X)]$ analiticamente para alguma funcao $h$ correlacionada com $g$, podemos corrigir nosso estimador:
+Se conhecemos $E[h(X)]$ para alguma funcao $h$ correlacionada com $g$:
 
 $$
 \hat{\theta}_{CV} = \hat{\theta}_N - c^*\left(\bar{h}_N - E[h(X)]\right)
 $$
 
-O coeficiente otimo minimiza a variancia:
+Coeficiente otimo:
 
 $$
 c^* = \frac{\text{Cov}(g(X), h(X))}{\text{Var}(h(X))}
 $$
 
-No coeficiente otimo $c^*$, a variancia se torna:
+Variancia no otimo:
 
 $$
 \text{Var}(\hat{\theta}_{CV}) = \frac{\text{Var}(g(X))}{N}(1 - \rho_{g,h}^2)
 $$
 
-onde $\rho_{g,h}$ e a correlacao entre $g$ e $h$.
-
-**Para nosso modelo de orcamento:** usando $h(X) = \sum S_i$ (soma bruta de salarios, com media analitica conhecida) como variavel de controle, obtemos $\rho \approx 0,99$, reduzindo a variancia por um fator de ~$(1 - 0,99^2) \approx 0,02$ — uma melhoria de aproximadamente **50×**.
+**No estudo de caso:** usando soma bruta de salarios como controle ($\rho \approx 0,99$) da ~50× de reducao. Em qualquer orcamento, o componente dominante com media analitica conhecida e a variavel de controle natural.
 
 ### Variaveis Antiteticas
 
-Gere pares $(X_i, X_i')$ onde $X_i' = F^{-1}(1 - F(X_i))$ e o "espelho" de $X_i$. O estimador usa medias par a par:
-
-$$
-\hat{\theta}_{AV} = \frac{1}{N/2}\sum_{i=1}^{N/2} \frac{g(X_i) + g(X_i')}{2}
-$$
-
-Se $g$ e monotona, $\text{Cov}(g(X), g(X')) < 0$, e a variancia e reduzida.
+Gere pares espelhados. Se $g$ e monotona, $\text{Cov}(g(X), g(X')) < 0$ e a variancia e reduzida.
 
 ### Amostragem Estratificada
 
-Particione o espaco de entrada em $K$ estratos, amostre proporcionalmente dentro de cada um e combine. Pela lei da variancia total:
+Particione o espaco de entrada em $K$ estratos. Pela lei da variancia total:
 
 $$
-\text{Var}(\hat{\theta}_{SS}) = \frac{1}{N}\sum_k p_k \sigma_k^2 \leq \frac{\sigma^2}{N} = \text{Var}(\hat{\theta}_{MC})
+\text{Var}(\hat{\theta}_{SS}) \leq \text{Var}(\hat{\theta}_{MC})
 $$
 
-A estratificacao remove a variancia entre estratos, que e sempre nao-negativa.
+Sempre. Remove a variancia entre estratos.
 
 ![Comparacao de Reducao de Variancia](../figures/variance_reduction_comparison.png)
-*Figura 3: Amplitude do IC vs N para MC simples, variaveis antiteticas e variaveis de controle. Variaveis de controle dominam.*
+*Figura 3: Amplitude do IC vs N para MC simples, variaveis antiteticas e variaveis de controle.*
 
 ---
 
 ## 8. Uma Alternativa Bayesiana
 
-A abordagem frequentista de Monte Carlo assume um modelo fixo e simula a partir dele. A abordagem Bayesiana trata parametros desconhecidos como variaveis aleatorias e atualiza crencas conforme dados chegam:
+A abordagem frequentista assume um modelo fixo e simula. A Bayesiana trata parametros como variaveis aleatorias e atualiza crencas com dados:
 
 $$
 P(\theta \mid \text{dados}) \propto P(\text{dados} \mid \theta) \cdot P(\theta)
 $$
 
-No contexto orcamentario: a **priori** e a distribuicao de custos do ano passado, a **verossimilhanca** sao os dados de gastos deste ano, e a **posteriori** e a previsao atualizada. Cada revisao de FYF e, na pratica, uma atualizacao Bayesiana informal.
+No orcamento: **priori** = distribuicao do periodo anterior, **verossimilhanca** = gastos observados, **posteriori** = forecast atualizado. Cada revisao periodica e atualizacao Bayesiana informal.
 
 | Aspecto | MC Frequentista | Bayesiano |
 |---------|----------------|-----------|
 | Parametros | Constantes fixas | Variaveis aleatorias |
-| Informacao a priori | Nao utilizada | Explicitamente codificada |
+| Informacao previa | Nao usada | Codificada explicitamente |
 | Saida | Intervalo de confianca | Intervalo de credibilidade |
-| Interpretacao | Frequencia de longo prazo | Probabilidade sobre $\theta$ |
-| Atualizacao no meio do ano | Requer re-especificacao | Natural (posteriori → nova priori) |
+| Atualizacao no periodo | Requer re-especificacao | Natural (posteriori → nova priori) |
+| Melhor quando | Sem dados historicos; exploracao de cenarios | Dados historicos disponiveis; revisao sequencial |
 
-Este artigo utiliza a abordagem frequentista por sua generalidade (nao requer elicitacao de priori), clareza pedagogica e simplicidade pratica. A extensao Bayesiana e um proximo passo natural para equipes com dados historicos de orcamento.
+Este artigo usa a abordagem frequentista por generalidade, clareza pedagogica e simplicidade pratica. A extensao Bayesiana e o proximo passo natural para equipes com historico.
 
 ---
 
@@ -325,45 +331,41 @@ Este artigo utiliza a abordagem frequentista por sua generalidade (nao requer el
 
 ### Experimento A: Convergencia da LGN
 
-Dez execucoes independentes da media amostral de salarios convergem para $E[S]$ conforme $N$ cresce (Figura 1). Em $N$ pequeno, as execucoes se espalham amplamente; em $N = 5.000$, todas se agrupam dentro de R$ 200 da media analitica.
+Dez execucoes convergem para $E[X]$ (Figura 1). Em $N$ pequeno, ampla dispersao; em $N = 5.000$, todas agrupadas dentro de R$ 200 da media analitica.
 
 ### Experimento B: Normalidade do TCL
 
-A media padronizada de salarios LogNormal e visivelmente nao-Normal em $n = 1$ mas se aproxima de $N(0,1)$ em $n = 30$ (Figura 2). Graficos QQ confirmam: $R^2 > 0,999$ em $n = 100$.
+Media padronizada visivelmente nao-Normal em $n = 1$, proxima de $N(0,1)$ em $n = 30$ (Figura 2). QQ-plots: $R^2 > 0,999$ em $n = 100$.
 
-### Experimento C: Simulacao Completa do Orcamento
+### Experimento C: Simulacao Completa
 
-Executando $N = 50.000$ iteracoes com parametros padrao:
+$N = 50.000$ iteracoes:
 
 ![Simulacao do Orcamento](../figures/budget_simulation.png)
-*Figura 4: Distribuicao do custo orcamentario (esquerda: histograma, direita: FDA) com media, P5/P95 e teto orcamentario anotados.*
+*Figura 4: Distribuicao (histograma + FDA) com media, P5/P95 e teto anotados.*
 
-A simulacao recupera o $E[X_{\text{total}}] \approx R\$ \, 11,55M$ analitico dentro de 0,1%. A distribuicao e assimetrica a direita (puxada pelos salarios LogNormal), com amplitude de 90% abrangendo aproximadamente R$ 1,6M.
+Recupera $E[X]$ analitico dentro de 0,1%. Distribuicao assimetrica a direita, faixa P5-P95 de ~R$ 1,6M.
 
 ### Experimento D: Reducao de Variancia
 
-Em $N = 5.000$, variaveis de controle reduzem a amplitude do IC de 95% em aproximadamente 10× comparado ao MC simples (Figura 3). O poder das variaveis de controle vem da alta correlacao ($\rho \approx 0,99$) entre custo total e soma bruta de salarios.
+Variaveis de controle reduzem amplitude do IC em ~10× vs MC simples (Figura 3).
 
 ### Experimento E: Analise de Sensibilidade
 
-Quais parametros importam mais? Variando cada parametro em ±20%:
+![Tornado de Sensibilidade](../figures/sensitivity_tornado.png)
+*Figura 5: Impacto dos parametros em $E[X_{\text{total}}]$.*
 
-![Grafico Tornado de Sensibilidade](../figures/sensitivity_tornado.png)
-*Figura 5: Grafico tornado mostrando impacto dos parametros em $E[X_{\text{total}}]$.*
-
-O log-media salarial $\mu_s$ e o headcount $n$ dominam. O multiplicador de beneficios $\beta$ tem impacto proporcional. Parametros de horas extras e incidentes tem efeito negligenciavel no total esperado — consistente com sua participacao de ~3% no orcamento.
-
-**Implicacao pratica:** melhorar a estimativa do salario medio importa muito mais do que refinar premissas de horas extras ou incidentes.
+Parametros do componente dominante (log-media salarial, headcount) geram a maior parte da variancia. **Implicacao pratica:** invista esforco em estimar os parametros do seu maior componente de custo.
 
 ### Principais Achados
 
 | Metrica | Valor |
 |---------|-------|
-| $E[X_{\text{total}}]$ analitico | R$ 11,55M |
+| $E[X]$ analitico | R$ 11,55M |
 | Media MC (N=50K) | Dentro de 0,1% do analitico |
-| Semi-amplitude do IC 95% (N=50K) | ~R$ 4K |
+| Semi-amplitude IC 95% (N=50K) | ~R$ 4K |
 | Faixa P5-P95 | ~R$ 1,6M |
-| Parametro mais sensivel | $\mu_s$ (log-media salarial) |
+| Parametro mais sensivel | Media do componente dominante |
 | Melhor reducao de variancia | Variaveis de controle (~10-50×) |
 
 ---
@@ -372,36 +374,47 @@ O log-media salarial $\mu_s$ e o headcount $n$ dominam. O multiplicador de benef
 
 ### Quando Usar Monte Carlo
 
-- **Use MC** quando o orcamento tem componentes estocasticos (headcount variavel, horas extras incertas, incidentes imprevisiveis) e voce precisa quantificar risco.
-- **Uma planilha basta** quando todos os componentes sao verdadeiramente deterministicos ou quando a incerteza e irrelevante para a decisao.
+- **Use MC** quando o orcamento tem componentes estocasticos e voce precisa quantificar risco.
+- **Planilha basta** quando tudo e deterministico ou a incerteza e irrelevante para a decisao.
 
-### Fluxo de Trabalho Recomendado
+### Fluxo de Trabalho
 
-1. **Defina o modelo.** Identifique quais componentes do orcamento sao aleatorios e escolha distribuicoes baseadas em dados historicos ou julgamento de especialistas.
-2. **Calcule momentos analiticos.** Calcule $E[X]$ e $\text{Var}(X)$ para validacao.
-3. **Execute uma simulacao piloto** ($N = 100$-$500$) para estimar $\sigma$ e determinar o $N$ necessario para a precisao desejada.
-4. **Execute a simulacao completa** com o $N$ calculado. Use variaveis de controle se uma boa variavel de controle existir.
-5. **Reporte resultados** como uma distribuicao: media, IC, P(acima do teto) e percentis chave.
+1. **Decomponha o orcamento** em componentes. Identifique quais tem incerteza significativa.
+2. **Escolha distribuicoes** baseadas em dados historicos, julgamento de especialistas ou analogias.
+3. **Calcule momentos analiticos** para validacao.
+4. **Execute simulacao piloto** ($N = 100$-$500$) para estimar $\sigma$ e computar $N$ necessario.
+5. **Execute simulacao completa** com $N$ calculado. Use variaveis de controle se disponiveis.
+6. **Reporte como distribuicao:** media, IC, P(acima do teto), percentis.
 
-### Como Apresentar Resultados
+### Como Apresentar
 
 Substitua:
 
-> "O orcamento de headcount de TI para o proximo ano e R$ 11,55M."
+> "O orcamento do proximo ano e R$ 11,55M."
 
 Por:
 
-> "Temos 95% de confianca de que o custo de headcount de TI ficara entre R$ 10,7M e R$ 12,4M, com media de R$ 11,55M. Ha aproximadamente 7% de probabilidade de ultrapassar o teto de R$ 12,5M. O principal direcionador de incerteza e a variancia salarial."
+> "Temos 95% de confianca de que o custo ficara entre R$ 10,7M e R$ 12,4M (media R$ 11,55M). Ha ~7% de probabilidade de ultrapassar o teto de R$ 12,5M. O principal fator de incerteza e [componente dominante]."
+
+### Adaptando ao Seu Contexto
+
+| Seu Orcamento | Componente Dominante | Variavel de Controle Natural | Distribuicao Provavel |
+|---------------|---------------------|------------------------------|----------------------|
+| Headcount | Salarios | Soma bruta de salarios | LogNormal |
+| Cloud/Infra | Uso de computacao | Custo de capacidade reservada | LogNormal ou Gamma |
+| Projetos | Horas de trabalho | Horas planejadas × taxa | LogNormal |
+| Procurement | Precos unitarios | Baseline contratual | Normal ou Uniforme |
+| Marketing | Volume de conversao | CPA historico | Poisson × LogNormal |
 
 ---
 
 ## 11. Conclusao
 
-Uma estimativa pontual de orcamento e uma unica amostra de uma distribuicao desconhecida. Ela nao carrega informacao sobre sua propria incerteza.
+Uma estimativa pontual de orcamento e uma unica amostra de uma distribuicao desconhecida. Nao carrega informacao sobre sua propria incerteza.
 
-Este artigo construiu a maquinaria matematica para substituir esse numero unico por uma distribuicao de probabilidade completa. Partindo da definicao de variaveis aleatorias, provamos que a media de simulacoes independentes converge para o custo esperado verdadeiro (Lei dos Grandes Numeros), quantificamos a taxa de convergencia (Teorema Central do Limite), formalizamos o estimador Monte Carlo e suas propriedades, e aplicamos tecnicas de reducao de variancia para tornar a simulacao eficiente.
+Este artigo construiu a maquinaria matematica para substituir esse numero unico por uma distribuicao de probabilidade completa. Partindo da definicao de variaveis aleatorias, provamos convergencia (LGN), quantificamos a taxa de convergencia (TCL), formalizamos o estimador Monte Carlo e aplicamos reducao de variancia.
 
-A validacao experimental confirmou: Monte Carlo recupera o valor esperado analitico, o TCL fornece intervalos de confianca calibrados, e variaveis de controle proporcionam uma melhoria de ordem de grandeza na precisao.
+O framework e geral: qualquer orcamento decomponivel em componentes estocasticos — headcount, projetos, infraestrutura, procurement — pode ser modelado assim. A validacao experimental confirmou que Monte Carlo recupera valores analiticos, o TCL fornece ICs calibrados, e variaveis de controle dao melhoria de ordem de grandeza.
 
 Da proxima vez que alguem pedir um numero de orcamento, entregue uma distribuicao.
 
@@ -428,4 +441,4 @@ python scripts/exp_sensitivity.py
 pytest tests/
 ```
 
-Todas as figuras sao geradas com seeds fixas para reprodutibilidade exata.
+Todas as figuras geradas com seeds fixas para reprodutibilidade exata.

--- a/article/monte-carlo-budget.md
+++ b/article/monte-carlo-budget.md
@@ -1,39 +1,47 @@
 # Why Your Budget Never Hits the Exact Number
 
-## Monte Carlo Simulation for IT Budget Planning — from Point Estimates to Probability Distributions
+## Monte Carlo Simulation for Budget Planning — from Point Estimates to Probability Distributions
 
 ---
 
 ## 1. Introduction
 
-Your CFO asks for next year's IT headcount budget. You open a spreadsheet, multiply headcount by average salary, add a benefits multiplier, toss in an overtime estimate, round up for incidents — and deliver a number. A single number. R$ 11.5 million.
+Someone asks for next year's budget. You open a spreadsheet, multiply quantities by unit costs, add contingencies, round up a little — and deliver a number. A single number.
 
 But what if that number is just one sample from a distribution you have never seen?
 
-Every organisation that manages headcount budgets — salaries, benefits, overtime, unplanned costs — faces the same ritual. The team produces a point estimate, leadership approves it, and the year unfolds. Months later, during a Forecast Year-end Financial (FYF) review, the actual spending deviates from the forecast. The team adjusts. Another review. Another adjustment. By year-end, the original number looks like little more than an educated guess.
+Every organisation that manages budgets — headcount costs, project expenses, procurement, marketing spend — faces the same ritual. The team produces a point estimate, leadership approves it, and the year unfolds. Months later, during a periodic forecast review, the actual spending deviates. The team adjusts. Another review. Another adjustment. By year-end, the original number looks like little more than an educated guess.
 
-The problem is not that the estimate was wrong. The problem is that a single number carries no information about its own uncertainty. Was R$ 11.5M a conservative estimate? An optimistic one? How likely are we to exceed R$ 12.5M? The point estimate cannot answer these questions — because it discards everything except the centre of the distribution.
+The problem is not that the estimate was wrong. The problem is that a single number carries no information about its own uncertainty. Was it a conservative estimate? An optimistic one? How likely are we to exceed the approved ceiling? The point estimate cannot answer these questions — because it discards everything except the centre of the distribution.
 
-This article replaces the single number with a **probability distribution**. Using Monte Carlo simulation grounded in the Law of Large Numbers and the Central Limit Theorem, we transform "we expect to spend R$ 11.5M" into "we are 90% confident spending will fall between R$ 10.7M and R$ 12.4M, with a 7% probability of exceeding the R$ 12.5M ceiling."
+This article replaces the single number with a **probability distribution**. Using Monte Carlo simulation grounded in the Law of Large Numbers and the Central Limit Theorem, we transform "we expect to spend R$ 11.5M" into "we are 90% confident spending will fall between R$ 10.7M and R$ 12.4M, with a 7% probability of exceeding the ceiling."
 
-The mathematical journey proceeds in four stages: we formalise the budget components as random variables (Section 3), prove that averaging simulations converges to the true answer (Section 4), quantify the simulation error (Section 5), and implement the estimator with variance reduction techniques (Sections 6–7). Section 9 validates everything experimentally.
+The approach is **general**: it applies to any budget that can be decomposed into stochastic components — headcount, projects, procurement, licensing, infrastructure. We illustrate with an IT headcount budget (salaries, benefits, overtime, incidents) as a concrete case study, but the mathematical framework transfers directly to any domain.
+
+The journey proceeds in four stages: we formalise budget components as random variables (Section 3), prove that averaging simulations converges to the true answer (Section 4), quantify the simulation error (Section 5), and implement the estimator with variance reduction techniques (Sections 6–7). Section 9 validates everything experimentally.
 
 ### Notation
 
-Throughout this article, we use the following notation:
+| Symbol | Meaning |
+|--------|---------|
+| $X_{\text{total}}$ | Total budget cost (random variable) |
+| $X_k$ | Cost of component $k$ |
+| $n$ | Number of units (headcount, items, etc.) |
+| $\bar{X}_N$ | Sample mean of $N$ simulations |
+| $\hat{\theta}_N$ | Monte Carlo estimator |
+| $\sigma$ | Standard deviation of the cost distribution |
+| $z_{\alpha/2}$ | Normal quantile for confidence level $1-\alpha$ |
+
+**Case study notation** (IT headcount):
 
 | Symbol | Meaning |
 |--------|---------|
 | $S_i$ | Monthly salary of employee $i$ |
-| $\beta$ | Benefits multiplier (encargos) |
-| $n$ | Number of employees (headcount) |
+| $\beta$ | Benefits multiplier |
 | $H_i$ | Overtime hours per employee per month |
 | $r_{ot}$ | Overtime hourly rate |
 | $I$ | Number of severe incidents per year |
 | $C_j$ | Cost of incident $j$ |
-| $X_{\text{total}}$ | Total annual budget cost |
-| $\bar{X}_N$ | Sample mean of $N$ simulations |
-| $\hat{\theta}_N$ | Monte Carlo estimator |
 
 ---
 
@@ -42,87 +50,99 @@ Throughout this article, we use the following notation:
 A point estimate is a single value used to approximate an unknown parameter. In budget planning, it takes the form:
 
 $$
-\hat{X} = n \times \bar{S} \times \beta \times 12 + \text{overtime} + \text{incidents}
+\hat{X} = \sum_{k} (\text{quantity}_k \times \text{unit cost}_k) + \text{contingency}
 $$
 
-where $\bar{S}$ is the average salary and everything else is a constant. The result is a number — say, R$ 11,554,473.
-
-But this number is $E[X_{\text{total}}]$: the expected value of a random variable. It tells us the centre of the distribution. What it discards is everything else:
+The result is a number — say, R$ 11.5 million. But this number is $E[X_{\text{total}}]$: the expected value of a random variable. It tells us the centre of the distribution. What it discards is everything else:
 
 - **Variance:** How spread out are the possible outcomes?
-- **Skewness:** Is the distribution symmetric, or could costs be pulled much higher by a few extreme salaries?
-- **Tail risk:** What is the probability of exceeding the approved budget?
-- **Confidence:** How sure are we that the true cost is within ±R$ 500K of our estimate?
+- **Skewness:** Is the distribution symmetric, or could costs be pulled higher by a few extreme events?
+- **Tail risk:** What is the probability of exceeding the approved ceiling?
+- **Confidence:** How sure are we that the true cost is within ±5% of our estimate?
 
 In formal terms, the point estimate gives us $E[X]$ but not the distribution $F_X$. Monte Carlo simulation recovers $F_X$ — the full picture.
 
+### The General Pattern
+
+Any budget with uncertain components can be written as:
+
+$$
+X_{\text{total}} = \sum_{k=1}^{K} g_k(\mathbf{Z}_k)
+$$
+
+where $g_k$ is a cost function for component $k$ and $\mathbf{Z}_k$ is a vector of random inputs. The point estimate collapses each $g_k$ to its expected value; Monte Carlo preserves the full joint distribution.
+
 ---
 
-## 3. Random Variables in Disguise
+## 3. Budget Components as Random Variables
 
-Every component of the budget is a random variable. Treating them as constants is a modelling choice that discards information.
+Every component of a budget is potentially a random variable. Treating them as constants is a modelling choice that discards information. The key insight: **identify which components carry meaningful uncertainty, model them probabilistically, and keep the rest deterministic.**
 
-### Salaries: LogNormal
+### The General Structure
 
-Salaries in a mixed-seniority IT team are strictly positive and right-skewed: most employees earn near the median, but a few senior engineers or managers earn significantly more. The LogNormal distribution captures this:
+A stochastic budget model has three types of components:
+
+1. **Proportional costs:** quantity × rate, where either or both may be random
+2. **Fixed costs with uncertainty:** known structure but uncertain magnitude
+3. **Rare events:** random count of occurrences × random cost per event (compound process)
 
 $$
-S_i \sim \text{LogNormal}(\mu_s, \sigma_s^2)
+X_{\text{total}} = \underbrace{\sum_{i=1}^{n} f(Z_i)}_{\text{proportional}} + \underbrace{\text{fixed components}}_{\text{deterministic or low-variance}} + \underbrace{\sum_{j=1}^{N_{\text{events}}} C_j}_{\text{rare events}}
 $$
 
-With parameters $\mu_s = 9.2$ and $\sigma_s = 0.3$, the expected monthly salary is:
+### Case Study: IT Headcount Budget
+
+We instantiate this structure with a concrete example — a 50-person IT team:
+
+**Salaries (LogNormal).** Salaries are strictly positive and right-skewed (a few senior roles earn significantly more). The LogNormal captures this:
+
+$$
+S_i \sim \text{LogNormal}(\mu_s, \sigma_s^2), \quad \mu_s = 9.2, \; \sigma_s = 0.3
+$$
 
 $$
 E[S_i] = e^{\mu_s + \sigma_s^2/2} = e^{9.245} \approx R\$ \, 10{,}362
 $$
 
-The variance is:
-
-$$
-\text{Var}(S_i) = (e^{\sigma_s^2} - 1) \cdot e^{2\mu_s + \sigma_s^2} \approx 10{,}117{,}947
-$$
-
-### Overtime: Poisson
-
-Overtime hours per employee per month are discrete, non-negative, and relatively rare — a natural fit for the Poisson distribution:
+**Overtime (Poisson).** Hours are discrete, non-negative, and relatively rare:
 
 $$
 H_i \sim \text{Poisson}(\lambda_h), \quad \lambda_h = 5
 $$
 
-A key property: for Poisson, $E[H_i] = \text{Var}(H_i) = \lambda_h$.
-
-### Incidents: Compound Poisson
-
-Severe incidents — outages, security breaches, emergency deployments — occur at a random rate with random severity:
+**Incidents (Compound Poisson).** Severe events occur at a random rate with random severity:
 
 $$
 I \sim \text{Poisson}(\lambda_I), \quad C_j \sim \text{LogNormal}(\mu_I, \sigma_I^2)
 $$
 
-The total incident cost is a **random sum of random variables**: $\sum_{j=1}^I C_j$.
-
-### The Total Cost Model
-
-Combining all components:
+**Total cost:**
 
 $$
 X_{\text{total}} = \underbrace{\sum_{i=1}^{n} S_i \cdot \beta \cdot 12}_{\text{salaries + benefits}} + \underbrace{\sum_{i=1}^{n} H_i \cdot r_{ot} \cdot 12}_{\text{overtime}} + \underbrace{\sum_{j=1}^{I} C_j}_{\text{incidents}}
 $$
 
-Using linearity of expectation (which holds regardless of independence):
-
-$$
-E[X_{\text{total}}] = n \cdot \beta \cdot 12 \cdot E[S_i] + n \cdot r_{ot} \cdot 12 \cdot E[H_i] + E[I] \cdot E[C_j]
-$$
-
-With default parameters ($n = 50$, $\beta = 1.80$, $r_{ot} = 80$, $\lambda_I = 3$):
+Using linearity of expectation:
 
 $$
 E[X_{\text{total}}] \approx 11{,}191{,}000 + 240{,}000 + 123{,}500 \approx R\$ \, 11{,}554{,}500
 $$
 
-The salary component dominates at ~97% of the total. This will matter for variance reduction later.
+The salary component dominates at ~97%. This pattern — one component driving most of the variance — is common across budget types and will matter for variance reduction.
+
+### Other Instantiations
+
+The same structure applies to:
+
+| Budget Type | Proportional | Fixed | Rare Events |
+|-------------|-------------|-------|-------------|
+| **IT Headcount** | Salaries × headcount | Benefits rate | Incidents |
+| **Cloud Infrastructure** | Usage × unit price | Reserved instances | Outage remediation |
+| **Marketing** | Impressions × CPC | Platform fees | Campaign failures |
+| **Construction** | Materials × quantity | Permits, insurance | Weather delays, rework |
+| **R&D Projects** | Hours × rate × team size | Equipment | Scope changes |
+
+In each case: identify the random components, choose distributions, and simulate.
 
 ---
 
@@ -150,12 +170,12 @@ $$
 
 **Proof.** Since $E[\bar{X}_N] = \mu$ and $\text{Var}(\bar{X}_N) = \sigma^2/N$, applying Chebyshev to $\bar{X}_N$ gives the result immediately. $\blacksquare$
 
-The Strong Law of Large Numbers provides an even stronger guarantee: $\bar{X}_N \to \mu$ almost surely, meaning the convergence happens with probability 1, not just in probability.
+The Strong Law provides an even stronger guarantee: $\bar{X}_N \to \mu$ almost surely (probability 1).
 
-**For Monte Carlo:** each simulation $X_i$ is one "possible year." The LLN guarantees that averaging $N$ simulated years converges to the true expected cost. Figure 1 demonstrates this visually.
+**For Monte Carlo:** each simulation $X_i$ is one "possible year." The LLN guarantees that averaging $N$ simulated scenarios converges to the true expected cost.
 
 ![LLN Convergence](../figures/lln_convergence.png)
-*Figure 1: Ten independent runs of the sample mean converging to $E[S]$, with Chebyshev 95% confidence band.*
+*Figure 1: Ten independent runs of the sample mean converging to $E[X]$, with Chebyshev 95% confidence band.*
 
 ---
 
@@ -182,10 +202,10 @@ $$
 Taylor expanding $\log M_W(s) = s^2/2 + O(s^3)$ and substituting $s = t/\sqrt{N}$:
 
 $$
-\log M_{Z_N}(t) = N \cdot \left[\frac{t^2}{2N} + O\left(\frac{t^3}{N^{3/2}}\right)\right] = \frac{t^2}{2} + O\left(\frac{t^3}{\sqrt{N}}\right) \to \frac{t^2}{2}
+\log M_{Z_N}(t) = \frac{t^2}{2} + O\left(\frac{t^3}{\sqrt{N}}\right) \to \frac{t^2}{2}
 $$
 
-Since $e^{t^2/2}$ is the MGF of $N(0, 1)$, the uniqueness theorem gives $Z_N \xrightarrow{d} N(0, 1)$. $\blacksquare$
+Since $e^{t^2/2}$ is the MGF of $N(0, 1)$, uniqueness gives $Z_N \xrightarrow{d} N(0, 1)$. $\blacksquare$
 
 ### Confidence Intervals
 
@@ -195,8 +215,6 @@ $$
 \bar{X}_N \pm z_{\alpha/2} \cdot \frac{s_N}{\sqrt{N}}
 $$
 
-where $s_N$ is the sample standard deviation and $z_{\alpha/2}$ is the Normal quantile (1.96 for 95%).
-
 ### Choosing N
 
 To achieve a CI half-width of $\epsilon$:
@@ -205,10 +223,10 @@ $$
 N \geq \left(\frac{z_{\alpha/2} \cdot \sigma}{\epsilon}\right)^2
 $$
 
-For our budget ($\sigma \approx 493K$, $\epsilon = 100K$, 95% confidence): $N \geq (1.96 \times 493{,}000 / 100{,}000)^2 \approx 94$. The CLT is remarkably efficient.
+For our case study ($\sigma \approx 493K$, $\epsilon = 100K$, 95%): $N \geq 94$. Remarkably few simulations are needed.
 
 ![CLT Normality Emergence](../figures/clt_normality_emergence.png)
-*Figure 2: As $n$ increases, the standardised mean of LogNormal salaries converges to $N(0,1)$.*
+*Figure 2: As $n$ increases, the standardised sample mean converges to $N(0,1)$.*
 
 ---
 
@@ -222,29 +240,25 @@ $$
 \hat{\theta}_N = \frac{1}{N} \sum_{i=1}^N g(X_i)
 $$
 
-where each $g(X_i)$ is the total cost from one simulated year.
+where each $g(X_i)$ is the total cost from one simulated scenario.
 
 ### Properties
 
-**Unbiasedness.** $E[\hat{\theta}_N] = \frac{1}{N}\sum E[g(X_i)] = \theta$. The estimator has no systematic bias.
+**Unbiasedness.** $E[\hat{\theta}_N] = \theta$. No systematic bias.
 
-**Consistency.** By the WLLN: $\hat{\theta}_N \xrightarrow{P} \theta$. More simulations means more accuracy.
+**Consistency.** $\hat{\theta}_N \xrightarrow{P} \theta$ (WLLN). More simulations → more accuracy.
 
-**Asymptotic normality.** By the CLT: $\sqrt{N}(\hat{\theta}_N - \theta)/\sigma_g \xrightarrow{d} N(0, 1)$. We can build confidence intervals.
+**Asymptotic normality.** $\sqrt{N}(\hat{\theta}_N - \theta)/\sigma_g \xrightarrow{d} N(0, 1)$ (CLT). We can build CIs.
 
-**Convergence rate.** The standard error is $\text{SE} = \sigma_g / \sqrt{N}$, which decays as $O(1/\sqrt{N})$. Crucially, this rate is **independent of the dimension** of $X$ — unlike deterministic integration methods that suffer from the curse of dimensionality.
+**Convergence rate.** $\text{SE} = \sigma_g / \sqrt{N}$, decaying as $O(1/\sqrt{N})$. This rate is **independent of the dimension** of $X$ — the key advantage over deterministic methods.
 
 ### The Scaling Law
 
-Halving the CI width requires 4× more simulations. Going from ±R$ 100K to ±R$ 50K means quadrupling $N$. This fundamental trade-off motivates variance reduction.
+Halving the CI width requires 4× more simulations. This fundamental trade-off motivates variance reduction.
 
 ### Mean Squared Error
 
-Since the estimator is unbiased:
-
-$$
-\text{MSE}(\hat{\theta}_N) = \text{Var}(\hat{\theta}_N) = \frac{\sigma_g^2}{N}
-$$
+Since the estimator is unbiased: $\text{MSE}(\hat{\theta}_N) = \sigma_g^2 / N$.
 
 ---
 
@@ -254,50 +268,48 @@ The $O(1/\sqrt{N})$ rate means brute-force precision is expensive. Variance redu
 
 ### Control Variates
 
-If we know $E[h(X)]$ analytically for some function $h$ correlated with $g$, we can correct our estimate:
+If we know $E[h(X)]$ analytically for some function $h$ correlated with the cost function $g$:
 
 $$
 \hat{\theta}_{CV} = \hat{\theta}_N - c^*\left(\bar{h}_N - E[h(X)]\right)
 $$
 
-The optimal coefficient minimises variance:
+The optimal coefficient:
 
 $$
 c^* = \frac{\text{Cov}(g(X), h(X))}{\text{Var}(h(X))}
 $$
 
-At this optimal $c^*$, the variance becomes:
+At optimal $c^*$, variance becomes:
 
 $$
 \text{Var}(\hat{\theta}_{CV}) = \frac{\text{Var}(g(X))}{N}(1 - \rho_{g,h}^2)
 $$
 
-where $\rho_{g,h}$ is the correlation between $g$ and $h$.
-
-**For our budget model:** using $h(X) = \sum S_i$ (total raw salaries, with known analytical mean) as the control variate yields $\rho \approx 0.99$, reducing variance by a factor of ~$(1 - 0.99^2) \approx 0.02$ — roughly a **50× improvement**.
+**In our case study:** using total raw salaries as control ($\rho \approx 0.99$) gives ~50× variance reduction. In any budget, the dominant cost component with a known analytical mean is the natural control variate.
 
 ### Antithetic Variates
 
-Generate pairs $(X_i, X_i')$ where $X_i' = F^{-1}(1 - F(X_i))$ is the "mirror" of $X_i$. The estimator uses pair-wise averages:
+Generate pairs $(X_i, X_i')$ where $X_i'$ is the "mirror" of $X_i$. If $g$ is monotone, the pair averages have lower variance:
 
 $$
-\hat{\theta}_{AV} = \frac{1}{N/2}\sum_{i=1}^{N/2} \frac{g(X_i) + g(X_i')}{2}
+\text{Var}(\hat{\theta}_{AV}) = \frac{1}{N}[\text{Var}(g(X)) + \text{Cov}(g(X), g(X'))]
 $$
 
-If $g$ is monotone, $\text{Cov}(g(X), g(X')) < 0$, and variance is reduced.
+When $\text{Cov} < 0$ (monotone $g$), variance is reduced.
 
 ### Stratified Sampling
 
-Partition the input space into $K$ strata, sample proportionally within each, and combine. By the law of total variance:
+Partition the input space into $K$ strata and sample within each. By the law of total variance:
 
 $$
-\text{Var}(\hat{\theta}_{SS}) = \frac{1}{N}\sum_k p_k \sigma_k^2 \leq \frac{\sigma^2}{N} = \text{Var}(\hat{\theta}_{MC})
+\text{Var}(\hat{\theta}_{SS}) \leq \text{Var}(\hat{\theta}_{MC})
 $$
 
-Stratification removes the between-strata variance, which is always non-negative.
+Always. Stratification removes between-strata variance.
 
 ![Variance Reduction Comparison](../figures/variance_reduction_comparison.png)
-*Figure 3: CI width vs N for naive MC, antithetic variates, and control variates. Control variates dominate.*
+*Figure 3: CI width vs N for naive MC, antithetic variates, and control variates.*
 
 ---
 
@@ -309,15 +321,15 @@ $$
 P(\theta \mid \text{data}) \propto P(\text{data} \mid \theta) \cdot P(\theta)
 $$
 
-In the budget context: the **prior** is last year's cost distribution, the **likelihood** is this year's spending data, and the **posterior** is the updated forecast. Each FYF review is, in practice, informal Bayesian updating.
+In budget terms: the **prior** is last year's cost distribution, the **likelihood** is this year's spending data, and the **posterior** is the updated forecast. Each periodic forecast revision is, in practice, informal Bayesian updating.
 
 | Aspect | Frequentist MC | Bayesian |
 |--------|---------------|----------|
 | Parameters | Fixed constants | Random variables |
 | Prior information | Not used | Explicitly encoded |
 | Output | Confidence interval | Credible interval |
-| Interpretation | Long-run frequency | Probability about $\theta$ |
-| Mid-year updating | Requires re-specification | Natural (posterior → new prior) |
+| Mid-period updating | Requires re-specification | Natural (posterior → new prior) |
+| Best when | No historical data; exploring scenarios | Historical data available; sequential revision |
 
 This article uses the frequentist approach for its generality (no prior elicitation needed), pedagogical clarity, and practical simplicity. The Bayesian extension is a natural next step for teams with historical budget data.
 
@@ -327,45 +339,41 @@ This article uses the frequentist approach for its generality (no prior elicitat
 
 ### Experiment A: LLN Convergence
 
-Ten independent runs of the salary sample mean converge to $E[S]$ as $N$ grows (Figure 1). At small $N$, the runs spread widely; by $N = 5{,}000$, all runs cluster within R$ 200 of the analytical mean. The Chebyshev 95% band confirms the convergence rate.
+Ten independent runs converge to $E[X]$ as $N$ grows (Figure 1). At small $N$, runs spread widely; by $N = 5{,}000$, all cluster within R$ 200 of the analytical mean.
 
 ### Experiment B: CLT Normality
 
-The standardised mean of LogNormal salaries is visibly non-Normal at $n = 1$ but closely matches $N(0,1)$ by $n = 30$ (Figure 2). QQ-plots confirm: $R^2 > 0.999$ at $n = 100$.
+The standardised mean is visibly non-Normal at $n = 1$ but closely matches $N(0,1)$ by $n = 30$ (Figure 2). QQ-plots confirm: $R^2 > 0.999$ at $n = 100$.
 
 ### Experiment C: Full Budget Simulation
 
-Running $N = 50{,}000$ iterations with default parameters:
+Running $N = 50{,}000$ iterations:
 
 ![Budget Simulation](../figures/budget_simulation.png)
-*Figure 4: Budget cost distribution (left: histogram, right: CDF) with mean, P5/P95, and budget ceiling annotated.*
+*Figure 4: Budget cost distribution (histogram + CDF) with mean, P5/P95, and budget ceiling annotated.*
 
-The simulation recovers the analytical $E[X_{\text{total}}] \approx R\$ \, 11.55M$ within 0.1%. The distribution is right-skewed (driven by LogNormal salaries), with a 90% range spanning roughly R$ 1.6M.
+The simulation recovers the analytical expected value within 0.1%. The distribution is right-skewed, with a 90% range spanning ~R$ 1.6M.
 
 ### Experiment D: Variance Reduction
 
-At $N = 5{,}000$, control variates reduce the 95% CI width by approximately 10× compared to naive MC (Figure 3). Antithetic variates provide a modest improvement. The control variate's power comes from the high correlation ($\rho \approx 0.99$) between total cost and raw salary sum.
+Control variates reduce the 95% CI width by ~10× compared to naive MC (Figure 3). The power comes from the high correlation between total cost and the dominant cost component.
 
 ### Experiment E: Sensitivity Analysis
-
-Which parameters matter most? Varying each parameter by ±20%:
 
 ![Sensitivity Tornado](../figures/sensitivity_tornado.png)
 *Figure 5: Tornado chart showing parameter impact on $E[X_{\text{total}}]$.*
 
-The salary log-mean $\mu_s$ and headcount $n$ dominate. Benefits multiplier $\beta$ has proportional impact. Overtime and incident parameters have negligible effect on the expected total — consistent with their ~3% share of the budget.
-
-**Practical implication:** improving the estimate of average salary matters far more than refining overtime or incident assumptions.
+The dominant cost component's parameters (salary log-mean, headcount) drive most of the variance. **Practical implication:** invest effort in estimating the parameters of your largest cost component, not the small ones.
 
 ### Key Findings
 
 | Metric | Value |
 |--------|-------|
-| Analytical $E[X_{\text{total}}]$ | R$ 11.55M |
+| Analytical $E[X]$ | R$ 11.55M |
 | MC mean (N=50K) | Within 0.1% of analytical |
 | 95% CI half-width (N=50K) | ~R$ 4K |
 | P5–P95 range | ~R$ 1.6M |
-| Most sensitive parameter | $\mu_s$ (salary log-mean) |
+| Most sensitive parameter | Dominant component's mean |
 | Best variance reduction | Control variates (~10–50×) |
 
 ---
@@ -374,26 +382,37 @@ The salary log-mean $\mu_s$ and headcount $n$ dominate. Benefits multiplier $\be
 
 ### When to Use Monte Carlo
 
-- **Use MC** when the budget has stochastic components (variable headcount, uncertain overtime, unpredictable incidents) and you need to quantify risk.
+- **Use MC** when the budget has stochastic components and you need to quantify risk — answer "what is the probability of exceeding the ceiling?"
 - **A spreadsheet suffices** when all components are truly deterministic or when uncertainty is irrelevant to the decision.
 
 ### Recommended Workflow
 
-1. **Define the model.** Identify which budget components are random and choose distributions based on historical data or expert judgement.
-2. **Compute analytical moments.** Calculate $E[X]$ and $\text{Var}(X)$ for validation.
-3. **Run a pilot simulation** ($N = 100$–$500$) to estimate $\sigma$ and determine the required $N$ for your desired precision.
-4. **Run the full simulation** with the computed $N$. Use control variates if a good control variable exists.
-5. **Report results** as a distribution: mean, CI, P(overbudget), and key percentiles.
+1. **Decompose the budget** into components. Identify which carry meaningful uncertainty.
+2. **Choose distributions** based on historical data, expert judgement, or analogies (LogNormal for costs, Poisson for counts, Normal for symmetric quantities).
+3. **Compute analytical moments** ($E[X]$, $\text{Var}(X)$) for validation.
+4. **Run a pilot simulation** ($N = 100$–$500$) to estimate $\sigma$ and compute the required $N$.
+5. **Run the full simulation** with the computed $N$. Use control variates if a good control variable exists.
+6. **Report as a distribution:** mean, CI, P(over ceiling), key percentiles.
 
 ### How to Present Results
 
 Replace:
 
-> "The IT headcount budget for next year is R$ 11.55M."
+> "The budget for next year is R$ 11.55M."
 
 With:
 
-> "We are 95% confident the IT headcount cost will fall between R$ 10.7M and R$ 12.4M, with a mean of R$ 11.55M. There is approximately a 7% probability of exceeding the R$ 12.5M ceiling. The primary driver of uncertainty is salary variance."
+> "We are 95% confident the cost will fall between R$ 10.7M and R$ 12.4M, with a mean of R$ 11.55M. There is approximately a 7% probability of exceeding the R$ 12.5M ceiling. The primary driver of uncertainty is [dominant component]."
+
+### Adapting to Your Context
+
+| Your Budget | Dominant Component | Natural Control Variate | Likely Distribution |
+|-------------|-------------------|------------------------|-------------------|
+| Headcount | Salaries | Total raw salary sum | LogNormal |
+| Cloud/Infra | Compute usage | Reserved capacity cost | LogNormal or Gamma |
+| Projects | Labour hours | Planned hours × rate | LogNormal |
+| Procurement | Unit prices | Contract baseline | Normal or Uniform |
+| Marketing | Conversion volume | Historical CPA | Poisson × LogNormal |
 
 ---
 
@@ -403,7 +422,7 @@ A point-estimate budget is a single sample from an unknown distribution. It carr
 
 This article built the mathematical machinery to replace that single number with a full probability distribution. Starting from the definition of random variables, we proved that averaging independent simulations converges to the true expected cost (Law of Large Numbers), quantified the convergence rate (Central Limit Theorem), formalised the Monte Carlo estimator and its properties, and applied variance reduction techniques to make the simulation efficient.
 
-The experimental validation confirmed: Monte Carlo recovers the analytical expected value, the CLT gives calibrated confidence intervals, and control variates provide an order-of-magnitude improvement in precision.
+The framework is general: any budget that can be decomposed into stochastic components — headcount, projects, infrastructure, procurement — can be modelled this way. The experimental validation confirmed that Monte Carlo recovers analytical expected values, the CLT gives calibrated confidence intervals, and control variates provide an order-of-magnitude improvement in precision.
 
 The next time someone asks for a budget number, give them a distribution.
 

--- a/docs/model-design.md
+++ b/docs/model-design.md
@@ -4,8 +4,9 @@
 
 The model is intentionally **generic and minimal** — few variables, clear
 structure, easy to expand. It models the annual cost of an IT team as a sum
-of stochastic components. No proprietary data is used; all parameters are
-realistic but synthetic.
+of stochastic components, serving as one concrete instantiation of a general
+budget template. No proprietary data is used; all parameters are realistic
+but synthetic.
 
 ## Variables
 
@@ -104,6 +105,54 @@ Consider a single simulation (one "possible year"):
 7. Sum all three terms: this is ONE sample of $X_{\text{total}}$
 
 Repeat 10,000 times to get the distribution of $X_{\text{total}}$.
+
+## Generalization
+
+### The Template Structure
+
+The IT headcount model above is one instantiation of a **general stochastic
+budget template** with three structural components:
+
+$$
+X_{\text{total}} = \underbrace{\text{Proportional costs}}_{\text{scale with a count}} + \underbrace{\text{Fixed / periodic costs}}_{\text{deterministic or low-variance}} + \underbrace{\text{Compound rare events}}_{\text{random count} \times \text{random severity}}
+$$
+
+This decomposition applies to any budget where:
+
+1. **Proportional costs** scale with some unit count (employees, servers,
+   campaigns) and each unit carries its own distributional uncertainty.
+2. **Fixed or periodic costs** are either deterministic or have low relative
+   variance (e.g., licensing fees, rent).
+3. **Rare disruptive events** occur at a random rate and carry variable cost
+   per occurrence (compound Poisson structure).
+
+### Other Budget Domains That Fit This Pattern
+
+| Domain | Proportional | Fixed / Periodic | Compound Events |
+|--------|-------------|-----------------|-----------------|
+| **Cloud infrastructure** | Per-instance compute cost (varies with workload) | Reserved-instance commitments, license fees | Outage-driven autoscaling spikes |
+| **Marketing** | Cost-per-lead times lead volume | Agency retainers, platform subscriptions | Viral campaign surges or PR crises |
+| **Construction projects** | Material cost per unit area | Permits, insurance, site overhead | Weather delays, supply-chain disruptions |
+
+### How to Instantiate the Template for a New Domain
+
+1. **Identify the unit count** — the quantity that drives proportional costs
+   (headcount, server count, campaign impressions, square metres). Decide
+   whether it is deterministic or stochastic.
+2. **Choose distributions for per-unit costs** — LogNormal is a good default
+   for positive, right-skewed costs; Normal works for tightly controlled prices.
+3. **Enumerate fixed charges** — list costs that do not scale with the unit
+   count. These can start as deterministic and be promoted to random variables
+   if uncertainty is material.
+4. **Model rare events as compound Poisson** — pick a Poisson rate for event
+   frequency and a distribution (e.g., LogNormal) for per-event severity.
+5. **Calibrate parameters** — use historical data, expert judgement, or
+   sensitivity analysis to set distribution parameters.
+6. **Validate analytically** — derive $E[X]$ and $\text{Var}(X)$ from the
+   chosen distributions and confirm that Monte Carlo results match.
+
+The mathematical machinery (LLN, CLT, variance reduction) carries over
+unchanged — only the parameter names and distributional choices differ.
 
 ## Expansion Points (documented, not implemented in v1)
 

--- a/docs/outline.md
+++ b/docs/outline.md
@@ -8,14 +8,14 @@
 
 **Source Phase:** —
 
-**Hook:** "Your CFO asks for next year's IT headcount budget. You open a
-spreadsheet, multiply headcount by average salary, add benefits, round up
-for overtime — and deliver a number. A single number. But what if that number
-is just one sample from a distribution you've never seen?"
+**Hook:** "Your CFO asks for next year's budget. You open a spreadsheet,
+multiply quantities by unit costs, add a contingency margin — and deliver a
+number. A single number. But what if that number is just one sample from a
+distribution you've never seen?"
 
 **Content:**
-- The FYF (Forecast Year-end Financial) context: periodic reviews to detect
-  budget deviations
+- The periodic forecast review context: why organisations revisit budgets
+  mid-cycle to detect deviations
 - Why point estimates are the default and why they fail
 - What this article offers: a mathematical framework for probabilistic budgeting
 - Preview of the journey: probability -> convergence -> CLT -> Monte Carlo -> results
@@ -35,14 +35,18 @@ is just one sample from a distribution you've never seen?"
 
 ---
 
-## Section 3 — Random Variables in Disguise (600 words)
+## Section 3 — Budget Components as Random Variables (600 words)
 
 **Source Phase:** Phase 1
 
+> **Note:** The framework is general — any budget with proportional costs, fixed
+> charges, and rare events fits the same template. IT headcount is the case
+> study used throughout this article.
+
 **Content:**
-- Salaries as LogNormal random variables: why the right-skew?
-- Overtime as Poisson: discrete, rare events
-- Incidents as compound Poisson: random count times random severity
+- General template: proportional + fixed + compound rare events
+- Case study instantiation: salaries (LogNormal), overtime (Poisson),
+  incidents (compound Poisson)
 - The budget model: $X = \sum S_i \cdot \beta \cdot 12 + \sum H_i \cdot r_{ot} \cdot 12 + \sum C_{I_j}$
 - Expected value and variance derivations (condensed)
 - Analytical E[X] for default parameters (for later validation)
@@ -119,7 +123,7 @@ is just one sample from a distribution you've never seen?"
 **Content:**
 - Conceptual overview: prior + likelihood -> posterior
 - Budget context: prior = last year's distribution, likelihood = this year's data
-- Connection to FYF: informal Bayesian updating in practice
+- Connection to periodic forecast reviews: informal Bayesian updating in practice
 - Comparison table: frequentist MC vs Bayesian
 - When each approach is more appropriate
 - Why this article chose frequentist: generality, no prior elicitation needed

--- a/docs/thesis.md
+++ b/docs/thesis.md
@@ -1,18 +1,22 @@
 # Thesis — Why Your Budget Never Hits the Exact Number
 
-## Central Claim (v0.1)
+## Central Claim (v0.2)
 
 > A point-estimate budget is a single sample from an unknown distribution — it
-> carries no information about its own uncertainty. Monte Carlo simulation
-> recovers the full distribution, turning "we expect to spend R$ 12M" into
-> "we are 90% confident spending will fall between R$ 11.2M and R$ 13.1M".
-> The mathematical guarantee comes from the Law of Large Numbers (convergence
-> of the estimator) and the Central Limit Theorem (quantification of the error).
+> carries no information about its own uncertainty. Any budget with stochastic
+> components (salaries, usage-based costs, rare disruptive events) is subject
+> to this limitation. Monte Carlo simulation recovers the full distribution,
+> turning "we expect to spend R$ 12M" into "we are 90% confident spending will
+> fall between R$ 11.2M and R$ 13.1M". The mathematical guarantee comes from
+> the Law of Large Numbers (convergence of the estimator) and the Central Limit
+> Theorem (quantification of the error).
 
 ## Central Axis
 
-Every budget estimate is a random variable. Treating it as a constant discards
-information.
+Every budget built from uncertain inputs is a random variable. Treating it as a
+constant discards information. This applies to any domain where costs combine
+proportional components, fixed charges, and rare events — IT headcount is one
+concrete instantiation; the framework is general.
 
 ```
 Point estimate = E[X]  (a single number)
@@ -35,8 +39,9 @@ Monte Carlo    = F_X   (the full distribution)
    sampling (derivations + implementation)
 6. **Bayesian comparison** — brief conceptual overview, frequentist vs
    Bayesian framing of budget estimation
-7. **Applied IT budget model** — generic headcount budget with salaries,
-   benefits, overtime, and incidents as stochastic components
+7. **Applied budget model** — a general stochastic budget template
+   (proportional costs + fixed charges + compound rare events), instantiated
+   as an IT headcount budget with salaries, benefits, overtime, and incidents
 
 ### Anti-Scope (What This Article Does NOT Cover)
 
@@ -49,10 +54,11 @@ Monte Carlo    = F_X   (the full distribution)
 
 ## Target Audience
 
-- Data scientists and analysts working with financial planning
+- Data scientists and analysts working with financial planning or cost modelling
 - Finance-adjacent tech roles (Analytics Engineers, BI developers)
+- Budget owners in any domain who rely on spreadsheet-based forecasts
 - Statisticians interested in applied simulation
-- Anyone who wants to understand why spreadsheet budgets are inherently limited
+- Anyone who wants to understand why point-estimate budgets are inherently limited
 
 ### Prerequisite Knowledge
 
@@ -62,16 +68,19 @@ Monte Carlo    = F_X   (the full distribution)
 
 ## Abstract
 
-Traditional IT budget planning relies on point estimates — single numbers that
-carry no information about their own uncertainty. When the CFO asks "what will
-we spend next year on headcount?", the answer is typically a deterministic
-calculation: headcount times average salary times benefits multiplier. This
-article argues that every component of that calculation is a random variable,
-and treating them as constants discards critical information. Using Monte Carlo
-simulation grounded in the Law of Large Numbers and Central Limit Theorem, we
-replace the single number with a probability distribution of outcomes. The
-result: not just "R$ 12M" but "90% confidence the budget falls between
-R$ 11.2M and R$ 13.1M, with a 7% probability of exceeding the ceiling." We
-derive the mathematical foundations from first principles, implement the
-simulation in Python, apply variance reduction techniques for efficiency, and
-demonstrate the approach on a generic IT headcount budget model.
+Traditional budget planning relies on point estimates — single numbers that
+carry no information about their own uncertainty. When a decision-maker asks
+"what will we spend next year?", the answer is typically a deterministic
+calculation: multiply quantities by unit costs, add a contingency margin, and
+deliver a single figure. This article argues that every component of such a
+calculation is a random variable, and treating them as constants discards
+critical information. Using Monte Carlo simulation grounded in the Law of Large
+Numbers and Central Limit Theorem, we replace the single number with a
+probability distribution of outcomes. The result: not just "R$ 12M" but "90%
+confidence the budget falls between R$ 11.2M and R$ 13.1M, with a 7%
+probability of exceeding the ceiling." We derive the mathematical foundations
+from first principles, implement the simulation in Python, apply variance
+reduction techniques for efficiency, and demonstrate the approach on an IT
+headcount budget — one concrete case study of a general stochastic budget
+template that applies wherever costs combine proportional components, fixed
+charges, and rare disruptive events.

--- a/notes/phase1-probability.md
+++ b/notes/phase1-probability.md
@@ -23,7 +23,7 @@ so that $P(X \in B)$ is well-defined.
 
 ### Connection to the Budget Model
 
-In our IT budget model, each salary $S_i$ is a random variable:
+In our budget model (here instantiated for IT headcount), each salary $S_i$ is a random variable:
 
 $$
 S_i : \Omega \to \mathbb{R}^+
@@ -58,7 +58,7 @@ $$
 The function $f_X$ is the **probability density function (PDF)**, and it
 satisfies $\int_{-\infty}^{\infty} f_X(x) \, dx = 1$.
 
-**In our model:** salaries $S_i$ and incident costs $C_{I_j}$ are continuous
+**In our budget model:** salaries $S_i$ and incident costs $C_{I_j}$ are continuous
 (LogNormal). Overtime hours $H_i$ and incident count $I$ are discrete (Poisson).
 
 ---

--- a/src/model.py
+++ b/src/model.py
@@ -1,8 +1,14 @@
 """Budget cost model for Monte Carlo simulation.
 
-This module defines the stochastic budget model for IT headcount planning.
-The model computes the total annual cost as the sum of three components:
-salaries with benefits, regular overtime, and incident-driven costs.
+This module implements the IT headcount instantiation of the general stochastic
+budget model template (proportional costs + fixed charges + compound rare
+events). The model computes the total annual cost as the sum of three
+components: salaries with benefits, regular overtime, and incident-driven costs.
+
+The same template structure applies to any budget domain — cloud
+infrastructure, marketing spend, construction projects, etc. — by swapping
+the variable names and distributional parameters. See the "Generalization"
+section in ``docs/model-design.md`` for guidance on adapting the template.
 
 All distributional choices and default parameters follow the specification
 in ``docs/model-design.md``.
@@ -15,7 +21,7 @@ import numpy as np
 
 @dataclass
 class BudgetModelParams:
-    """Parameters for the IT headcount budget model.
+    """Parameters for the budget model (IT headcount instantiation).
 
     Parameters
     ----------
@@ -76,7 +82,12 @@ class YearResult:
 
 
 class BudgetModel:
-    """Stochastic budget model for IT headcount planning.
+    """Stochastic budget model (IT headcount instantiation).
+
+    This class implements the IT headcount instantiation of the general
+    stochastic budget model template (proportional + fixed + compound events).
+    The three-term structure generalises to any domain; see
+    ``docs/model-design.md`` for the template and adaptation instructions.
 
     The total annual cost is:
 


### PR DESCRIPTION
## Summary

Generalize the project framing from "IT headcount budget" to "generic
stochastic budget modelling with IT headcount as case study."

- Article (EN + PT): rewritten intro, generic structure template, table of
  5 budget types, adapted practical framework with domain adaptation guide
- docs/thesis.md: thesis v0.2 — applies to any budget with stochastic components
- docs/model-design.md: new Generalization section — 3-component template,
  3 domain examples (cloud, marketing, construction), instantiation guide
- docs/outline.md: section titles genericized, FYF references removed
- README.md: "Stochastic Budget Modelling" with IT as case study
- src/model.py: docstrings clarify this is one instantiation
- notes/phase1: softened IT-specific phrasing (no math changed)

Closes #19, #20

## Type of Change

- [x] Refactor (`refactor`)
- [x] Documentation (`docs`)

## Checklist

- [x] No math or code logic changed
- [x] All figures still referenced correctly
- [x] No hardcoded paths or secrets